### PR TITLE
Fix test assert timing bug (missing Carbon::setTestNow)

### DIFF
--- a/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingPublicKeyCredentialTests.php
+++ b/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingPublicKeyCredentialTests.php
@@ -188,6 +188,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
     /** @test */
     public function it_automatically_enables_sudo_mode_when_the_user_completes_the_multi_factor_challenge_using_a_public_key_credential(): void
     {
+        Carbon::setTestNow('2021-01-01 00:00:00');
         Event::fake([Authenticated::class, MultiFactorChallengeFailed::class]);
         $user = $this->generateUser(['id' => 1]);
         $credential = MultiFactorCredential::factory()->publicKey()->forUser($user)->create([


### PR DESCRIPTION
See https://github.com/claudiodekker/laravel-auth-bladebones/actions/runs/3756014719/jobs/6381617818