### PR TITLE
Recovery: Skip the recovery code challenge when no codes exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/claudiodekker/laravel-auth/compare/v0.1.0...HEAD)
 
-## Added
+### Added
 
 - PHP 8.2 Support ([#6](https://github.com/claudiodekker/laravel-auth/pull/6))
 - The Passkey-based registration flow can now be cancelled, directly releasing the claimed user ([#7](https://github.com/claudiodekker/laravel-auth/pull/7))
 - `exec` generator method, providing an easy way to run cli commands ([#8](https://github.com/claudiodekker/laravel-auth/pull/8))
 - New Account Security Strength Indicator ([#11](https://github.com/claudiodekker/laravel-auth/pull/11))
 
-## Fixed
+### Changed
+
+- The recovery challenge will now be skipped when no codes have been configured ([#13](https://github.com/claudiodekker/laravel-auth/pull/13))
+
+### Fixed
 
 - fakerphp/faker 1.14: Accessing property "dateTime" is deprecated ([`ffd680a`](https://github.com/claudiodekker/laravel-auth/commit/ffd680a65746c8c0fe7384644979f1960242659e))
 - Removed unnecessary `composer.lock` file ([`ffd680a`](https://github.com/claudiodekker/laravel-auth/commit/ffd680a65746c8c0fe7384644979f1960242659e))

--- a/src/Testing/Partials/Challenges/Recovery/ViewAccountRecoveryChallengePageTests.php
+++ b/src/Testing/Partials/Challenges/Recovery/ViewAccountRecoveryChallengePageTests.php
@@ -4,6 +4,11 @@ namespace ClaudioDekker\LaravelAuth\Testing\Partials\Challenges\Recovery;
 
 use App\Providers\RouteServiceProvider;
 use Carbon\Carbon;
+use ClaudioDekker\LaravelAuth\Events\AccountRecovered;
+use ClaudioDekker\LaravelAuth\Events\AccountRecoveryFailed;
+use ClaudioDekker\LaravelAuth\Events\SudoModeEnabled;
+use ClaudioDekker\LaravelAuth\Http\Middleware\EnsureSudoMode;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Password;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -12,7 +17,7 @@ trait ViewAccountRecoveryChallengePageTests
     /** @test */
     public function the_account_recovery_challenge_page_can_be_viewed(): void
     {
-        $user = $this->generateUser();
+        $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $token = Password::getRepository()->create($user);
 
         $response = $this->get(route('recover-account.challenge', [
@@ -24,9 +29,33 @@ trait ViewAccountRecoveryChallengePageTests
     }
 
     /** @test */
+    public function the_account_recovery_challenge_page_is_skipped_when_the_user_does_not_have_any_recovery_codes(): void
+    {
+        Event::fake([AccountRecovered::class, AccountRecoveryFailed::class, SudoModeEnabled::class]);
+        $user = $this->generateUser(['recovery_codes' => null]);
+        $repository = Password::getRepository();
+        $token = $repository->create($user);
+        $this->assertTrue($repository->exists($user, $token));
+
+        $response = $this->get(route('recover-account.challenge', [
+            'token' => $token,
+            'email' => $user->getEmailForPasswordReset(),
+        ]));
+
+        $response->assertRedirect(route('auth.settings'));
+        $response->assertSessionMissing(EnsureSudoMode::REQUIRED_AT_KEY);
+        $response->assertSessionHas(EnsureSudoMode::CONFIRMED_AT_KEY, now()->unix());
+        $this->assertFullyAuthenticatedAs($response, $user);
+        $this->assertFalse($repository->exists($user, $token));
+        Event::assertDispatched(AccountRecovered::class, fn ($event) => $event->user->is($user) && $event->request === request());
+        Event::assertNotDispatched(AccountRecoveryFailed::class);
+        Event::assertNotDispatched(SudoModeEnabled::class);
+    }
+
+    /** @test */
     public function the_account_recovery_challenge_page_cannot_be_viewed_when_authenticated(): void
     {
-        $user = $this->generateUser();
+        $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
 
         $response = $this->actingAs($user)
             ->get(route('recover-account.challenge', ['token' => 'foo']));
@@ -37,7 +66,7 @@ trait ViewAccountRecoveryChallengePageTests
     /** @test */
     public function the_account_recovery_challenge_page_cannot_be_viewed_when_the_provided_email_does_not_resolve_to_an_existing_user(): void
     {
-        $user = $this->generateUser();
+        $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $token = Password::getRepository()->create($user);
 
         $response = $this->get(route('recover-account.challenge', [
@@ -53,8 +82,8 @@ trait ViewAccountRecoveryChallengePageTests
     /** @test */
     public function the_account_recovery_challenge_page_cannot_be_viewed_when_the_recovery_token_does_not_belong_to_the_user_that_is_being_recovered(): void
     {
-        $userA = $this->generateUser(['id' => 1, 'email' => 'claudio@ubient.net']);
-        $userB = $this->generateUser(['id' => 2, 'email' => 'another@example.com', $this->usernameField() => $this->anotherUsername()]);
+        $userA = $this->generateUser(['id' => 1, 'email' => 'claudio@ubient.net', 'recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
+        $userB = $this->generateUser(['id' => 2, 'email' => 'another@example.com', $this->usernameField() => $this->anotherUsername(), 'recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $token = Password::getRepository()->create($userA);
 
         $response = $this->get(route('recover-account.challenge', [
@@ -70,7 +99,7 @@ trait ViewAccountRecoveryChallengePageTests
     /** @test */
     public function the_account_recovery_challenge_page_cannot_be_viewed_when_the_recovery_token_does_not_exist(): void
     {
-        $user = $this->generateUser();
+        $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
 
         $response = $this->get(route('recover-account.challenge', [
             'token' => 'invalid-token',
@@ -86,7 +115,7 @@ trait ViewAccountRecoveryChallengePageTests
     public function the_account_recovery_challenge_page_cannot_be_viewed_when_the_recovery_token_has_expired(): void
     {
         Carbon::setTestNow('2022-01-01 00:00:00');
-        $user = $this->generateUser();
+        $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $token = Password::getRepository()->create($user);
         Carbon::setTestNow(now()->addHour()->addSecond());
 


### PR DESCRIPTION
Closes #2 

This change will make it so that the system will 'skip' the recovery code challenge in the situation that you did not generate recovery codes, similar to what would happen when you did not configure 2FA and try to authenticate. This puts the responsibility as to generate recovery codes with the user.