### PR TITLE
Session keys: Use `auth` namespace instead of `laravel-auth::`

### DIFF
--- a/src/Http/Concerns/Challenges/PublicKeyChallenge.php
+++ b/src/Http/Concerns/Challenges/PublicKeyChallenge.php
@@ -188,7 +188,7 @@ trait PublicKeyChallenge
      */
     protected function publicKeyChallengeOptionsKey(Request $request): string
     {
-        return 'laravel-auth::public_key_challenge_request_options';
+        return 'auth.public_key_challenge_request_options';
     }
 
     /**

--- a/src/Http/Concerns/Login/PasswordBasedAuthentication.php
+++ b/src/Http/Concerns/Login/PasswordBasedAuthentication.php
@@ -126,7 +126,7 @@ trait PasswordBasedAuthentication
      */
     protected function sanitizeMultiFactorSessionState(Request $request): void
     {
-        $request->session()->forget('laravel-auth::public_key_challenge_request_options');
+        $request->session()->forget('auth.public_key_challenge_request_options');
     }
 
     /**

--- a/src/Http/Controllers/Challenges/SudoModeChallengeController.php
+++ b/src/Http/Controllers/Challenges/SudoModeChallengeController.php
@@ -189,6 +189,6 @@ abstract class SudoModeChallengeController
      */
     protected function publicKeyChallengeOptionsKey(Request $request): string
     {
-        return 'laravel-auth::sudo_mode.public_key_challenge_request_options';
+        return 'auth.sudo_mode.public_key_challenge_request_options';
     }
 }

--- a/src/Testing/Helpers.php
+++ b/src/Testing/Helpers.php
@@ -186,7 +186,7 @@ trait Helpers
             Collection::make($allowedCredentials)->map(fn ($credential) => CredentialAttributes::fromJson($credential->secret))
         );
 
-        Session::put('laravel-auth::public_key_challenge_request_options', serialize($options));
+        Session::put('auth.public_key_challenge_request_options', serialize($options));
 
         return $options;
     }

--- a/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingPublicKeyCredentialTests.php
+++ b/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingPublicKeyCredentialTests.php
@@ -47,7 +47,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         $response->assertExactJson(['redirect_url' => RouteServiceProvider::HOME]);
         $this->assertFullyAuthenticatedAs($response, $user);
         $this->assertMissingRememberCookie($response, $user);
-        $this->assertFalse(Session::has('laravel-auth::public_key_challenge_request_options'));
+        $this->assertFalse(Session::has('auth.public_key_challenge_request_options'));
         Event::assertNotDispatched(MultiFactorChallengeFailed::class);
         Event::assertDispatched(Authenticated::class, fn (Authenticated $event) => $event->user->is($user));
         $this->assertSame(123, CredentialAttributes::fromJson($credential->fresh()->secret)->signCount());
@@ -81,7 +81,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         $response->assertStatus(428);
         $this->assertSame('The current authentication challenge state is invalid.', $response->exception->getMessage());
         $this->assertPartlyAuthenticatedAs($response, $user);
-        $this->assertFalse(Session::has('laravel-auth::public_key_challenge_request_options'));
+        $this->assertFalse(Session::has('auth.public_key_challenge_request_options'));
         $this->assertSame(117, CredentialAttributes::fromJson($credential->fresh()->secret)->signCount());
         Event::assertNothingDispatched();
     }
@@ -115,7 +115,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         $response->assertStatus(422);
         $response->assertJsonValidationErrors(['credential' => [__('laravel-auth::auth.challenge.public-key')]]);
         $this->assertPartlyAuthenticatedAs($response, $user);
-        $this->assertTrue(Session::has('laravel-auth::public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.public_key_challenge_request_options'));
         $this->assertSame(117, CredentialAttributes::fromJson($credential->fresh()->secret)->signCount());
         Event::assertNotDispatched(Authenticated::class);
         Event::assertDispatched(MultiFactorChallengeFailed::class, fn (MultiFactorChallengeFailed $event) => $event->user->is($user) && $event->type === CredentialType::PUBLIC_KEY);
@@ -150,7 +150,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         $response->assertStatus(422);
         $response->assertJsonValidationErrors(['credential' => [__('laravel-auth::auth.challenge.public-key')]]);
         $this->assertPartlyAuthenticatedAs($response, $user);
-        $this->assertTrue(Session::has('laravel-auth::public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.public_key_challenge_request_options'));
         $this->assertSame(123, CredentialAttributes::fromJson($credential->fresh()->secret)->signCount());
         Event::assertNotDispatched(Authenticated::class);
         Event::assertDispatched(MultiFactorChallengeFailed::class, fn (MultiFactorChallengeFailed $event) => $event->user->is($user) && $event->type === CredentialType::PUBLIC_KEY);
@@ -185,7 +185,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         $response->assertStatus(422);
         $response->assertJsonValidationErrors(['credential' => [__('laravel-auth::auth.challenge.public-key')]]);
         $this->assertPartlyAuthenticatedAs($response, $user);
-        $this->assertTrue(Session::has('laravel-auth::public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.public_key_challenge_request_options'));
         $this->assertSame(117, CredentialAttributes::fromJson($credential->fresh()->secret)->signCount());
         Event::assertDispatched(MultiFactorChallengeFailed::class, fn (MultiFactorChallengeFailed $event) => $event->user->is($user) && $event->type === CredentialType::PUBLIC_KEY);
         Event::assertNotDispatched(Authenticated::class);
@@ -295,7 +295,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         $response->assertExactJson(['redirect_url' => RouteServiceProvider::HOME]);
         $this->assertFullyAuthenticatedAs($response, $user);
         $this->assertMissingRememberCookie($response, $user);
-        $this->assertFalse(Session::has('laravel-auth::public_key_challenge_request_options'));
+        $this->assertFalse(Session::has('auth.public_key_challenge_request_options'));
         Event::assertNotDispatched(MultiFactorChallengeFailed::class);
         Event::assertDispatched(Authenticated::class, fn (Authenticated $event) => $event->user->is($user));
         $this->assertSame(123, CredentialAttributes::fromJson($credential->fresh()->secret)->signCount());
@@ -365,6 +365,6 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         // The result is a state in which the victim is being authenticated, with the attacker's MFA challenge details still set.
         // At this point all the attacker has to do, is to confirm their own MFA challenge, to be signed in as the victim.
         // To prevent this, we'll make sure to always clear any MFA challenge details during the initial login attempt.
-        $this->assertFalse(Session::has('laravel-auth::public_key_challenge_request_options'));
+        $this->assertFalse(Session::has('auth.public_key_challenge_request_options'));
     }
 }

--- a/src/Testing/Partials/Challenges/MultiFactor/ViewMultiFactorChallengePageTests.php
+++ b/src/Testing/Partials/Challenges/MultiFactor/ViewMultiFactorChallengePageTests.php
@@ -28,7 +28,7 @@ trait ViewMultiFactorChallengePageTests
         $response = $this->get(route('login.challenge.multi_factor'));
 
         $response->assertOk();
-        $this->assertInstanceOf(PublicKeyCredentialRequestOptions::class, $options = unserialize(Session::get('laravel-auth::public_key_challenge_request_options'), [PublicKeyCredentialRequestOptions::class]));
+        $this->assertInstanceOf(PublicKeyCredentialRequestOptions::class, $options = unserialize(Session::get('auth.public_key_challenge_request_options'), [PublicKeyCredentialRequestOptions::class]));
         $this->assertSame([
             'challenge' => $challenge,
             'rpId' => $rpId,
@@ -51,12 +51,12 @@ trait ViewMultiFactorChallengePageTests
         LaravelAuth::multiFactorCredential()::factory()->forUser($user)->totp()->create();
         $response = $this->preAuthenticate($user);
         $response->assertExactJson(['redirect_url' => route('login.challenge.multi_factor')]);
-        $this->assertFalse(Session::has('laravel-auth::public_key_challenge_request_options'));
+        $this->assertFalse(Session::has('auth.public_key_challenge_request_options'));
 
         $response = $this->get(route('login.challenge.multi_factor'));
 
         $response->assertOk();
-        $response->assertSessionMissing('laravel-auth::public_key_challenge_request_options');
+        $response->assertSessionMissing('auth.public_key_challenge_request_options');
     }
 
     /** @test */
@@ -75,7 +75,7 @@ trait ViewMultiFactorChallengePageTests
         $response->assertRedirect($intendedLocation);
         $this->assertFullyAuthenticatedAs($response, $user);
         $this->assertMissingRememberCookie($response, $user);
-        $this->assertFalse(Session::has('laravel-auth::public_key_challenge_request_options'));
+        $this->assertFalse(Session::has('auth.public_key_challenge_request_options'));
         Event::assertNotDispatched(MultiFactorChallengeFailed::class);
         Event::assertDispatched(Authenticated::class, fn (Authenticated $event) => $event->user->is($user));
     }

--- a/src/Testing/Partials/Challenges/SudoMode/ConfirmSudoModeUsingCredentialTests.php
+++ b/src/Testing/Partials/Challenges/SudoMode/ConfirmSudoModeUsingCredentialTests.php
@@ -31,7 +31,7 @@ trait ConfirmSudoModeUsingCredentialTests
         Config::set('laravel-auth.webauthn.relying_party.id', 'localhost');
         $this->mockWebauthnChallenge('G0JbLLndef3a0Iy3S2sSQA8uO4SO/ze6FZMAuPI6+xI=');
         $this->actingAs($user)->get(route('auth.sudo_mode'));
-        $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -51,7 +51,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $response->assertExactJson(['redirect_url' => $redirectsTo]);
         $response->assertSessionMissing(EnsureSudoMode::REQUIRED_AT_KEY);
         $response->assertSessionHas(EnsureSudoMode::CONFIRMED_AT_KEY, now()->unix());
-        $response->assertSessionMissing('laravel-auth::sudo_mode.public_key_challenge_request_options');
+        $response->assertSessionMissing('auth.sudo_mode.public_key_challenge_request_options');
         Event::assertNotDispatched(SudoModeChallenged::class);
         Event::assertDispatched(SudoModeEnabled::class, fn (SudoModeEnabled $event) => $event->request === request() && $event->user->is($user));
         Carbon::setTestNow();
@@ -71,7 +71,7 @@ trait ConfirmSudoModeUsingCredentialTests
         Config::set('laravel-auth.webauthn.relying_party.id', 'localhost');
         $this->mockWebauthnChallenge('G0JbLLndef3a0Iy3S2sSQA8uO4SO/ze6FZMAuPI6+xI=');
         $this->actingAs($user)->get(route('auth.sudo_mode'));
-        $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -91,7 +91,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $this->assertSame(['credential' => [__('laravel-auth::auth.challenge.public-key')]], $response->exception->errors());
         $response->assertSessionHas(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $response->assertSessionMissing(EnsureSudoMode::CONFIRMED_AT_KEY);
-        $response->assertSessionHas('laravel-auth::sudo_mode.public_key_challenge_request_options');
+        $response->assertSessionHas('auth.sudo_mode.public_key_challenge_request_options');
         Event::assertNothingDispatched();
         Carbon::setTestNow();
     }
@@ -110,7 +110,7 @@ trait ConfirmSudoModeUsingCredentialTests
         Config::set('laravel-auth.webauthn.relying_party.id', 'localhost');
         $this->mockWebauthnChallenge('G0JbLLndef3a0Iy3S2sSQA8uO4SO/ze6FZMAuPI6+xI=');
         $this->actingAs($user)->get(route('auth.sudo_mode'));
-        $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -130,7 +130,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $this->assertSame(['credential' => [__('laravel-auth::auth.challenge.public-key')]], $response->exception->errors());
         $response->assertSessionHas(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $response->assertSessionMissing(EnsureSudoMode::CONFIRMED_AT_KEY);
-        $response->assertSessionHas('laravel-auth::sudo_mode.public_key_challenge_request_options');
+        $response->assertSessionHas('auth.sudo_mode.public_key_challenge_request_options');
         Event::assertNothingDispatched();
         Carbon::setTestNow();
     }
@@ -154,7 +154,7 @@ trait ConfirmSudoModeUsingCredentialTests
         Config::set('laravel-auth.webauthn.relying_party.id', 'localhost');
         $this->mockWebauthnChallenge('G0JbLLndef3a0Iy3S2sSQA8uO4SO/ze6FZMAuPI6+xI=');
         $this->actingAs($userA)->get(route('auth.sudo_mode'));
-        $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
 
         $response = $this->actingAs($userA)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -174,7 +174,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $response->assertJsonValidationErrors(['credential' => [__('laravel-auth::auth.challenge.public-key')]]);
         $response->assertSessionHas(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $response->assertSessionMissing(EnsureSudoMode::CONFIRMED_AT_KEY);
-        $response->assertSessionHas('laravel-auth::sudo_mode.public_key_challenge_request_options');
+        $response->assertSessionHas('auth.sudo_mode.public_key_challenge_request_options');
         Event::assertNothingDispatched();
         Carbon::setTestNow();
     }
@@ -194,7 +194,7 @@ trait ConfirmSudoModeUsingCredentialTests
         Config::set('laravel-auth.webauthn.relying_party.id', 'authtest.wrp.app');
         $this->mockWebauthnChallenge('R9KnmyTxs6zHJB75bhLKgw');
         $this->actingAs($user)->get(route('auth.sudo_mode'));
-        $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -214,7 +214,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $response->assertExactJson(['redirect_url' => $redirectsTo]);
         $response->assertSessionMissing(EnsureSudoMode::REQUIRED_AT_KEY);
         $response->assertSessionHas(EnsureSudoMode::CONFIRMED_AT_KEY, now()->unix());
-        $response->assertSessionMissing('laravel-auth::sudo_mode.public_key_challenge_request_options');
+        $response->assertSessionMissing('auth.sudo_mode.public_key_challenge_request_options');
         Event::assertNotDispatched(SudoModeChallenged::class);
         Event::assertDispatched(SudoModeEnabled::class, fn (SudoModeEnabled $event) => $event->request === request() && $event->user->is($user));
         Carbon::setTestNow();
@@ -251,7 +251,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $this->assertSame('The current confirmation state is invalid.', $response->exception->getMessage());
         $response->assertSessionHas(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $response->assertSessionMissing(EnsureSudoMode::CONFIRMED_AT_KEY);
-        $response->assertSessionMissing('laravel-auth::sudo_mode.public_key_challenge_request_options');
+        $response->assertSessionMissing('auth.sudo_mode.public_key_challenge_request_options');
         Event::assertNothingDispatched();
         Carbon::setTestNow();
     }
@@ -272,7 +272,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $this->assertSame(['credential' => ['The credential field is required.']], $response->exception->errors());
         $response->assertSessionHas(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $response->assertSessionMissing(EnsureSudoMode::CONFIRMED_AT_KEY);
-        $response->assertSessionMissing('laravel-auth::sudo_mode.public_key_challenge_request_options');
+        $response->assertSessionMissing('auth.sudo_mode.public_key_challenge_request_options');
         Carbon::setTestNow();
         Event::assertNothingDispatched();
     }

--- a/src/Testing/Partials/Challenges/SudoMode/ViewSudoModeChallengePageTests.php
+++ b/src/Testing/Partials/Challenges/SudoMode/ViewSudoModeChallengePageTests.php
@@ -14,12 +14,12 @@ trait ViewSudoModeChallengePageTests
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $user = $this->generateUser();
         MultiFactorCredential::factory()->publicKey()->forUser($user)->create();
-        $this->assertFalse(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->assertFalse(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
 
         $response = $this->actingAs($user)->get(route('auth.sudo_mode'));
 
         $response->assertOk();
-        $response->assertSessionHas('laravel-auth::sudo_mode.public_key_challenge_request_options');
+        $response->assertSessionHas('auth.sudo_mode.public_key_challenge_request_options');
     }
 
     /** @test */
@@ -27,12 +27,12 @@ trait ViewSudoModeChallengePageTests
     {
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $user = $this->generateUser();
-        $this->assertFalse(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->assertFalse(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
 
         $response = $this->actingAs($user)->get(route('auth.sudo_mode'));
 
         $response->assertOk();
-        $response->assertSessionMissing('laravel-auth::sudo_mode.public_key_challenge_request_options');
+        $response->assertSessionMissing('auth.sudo_mode.public_key_challenge_request_options');
     }
 
     /** @test */

--- a/src/Testing/Partials/RateLimiting/SudoModeRateLimitingTests.php
+++ b/src/Testing/Partials/RateLimiting/SudoModeRateLimitingTests.php
@@ -76,7 +76,7 @@ trait SudoModeRateLimitingTests
         $user = $this->generateUser(['id' => 1]);
         MultiFactorCredential::factory()->publicKey()->forUser($user)->create();
         $this->actingAs($user)->get(route('auth.sudo_mode'));
-        $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
         $mock = RateLimiter::partialMock();
         $mock->shouldReceive('tooManyAttempts')->once()->withSomeOfArgs($this->predictableSudoRateLimitingKey($user))->andReturn(true);
         $mock->shouldReceive('availableIn')->once()->andReturn(75);
@@ -109,7 +109,7 @@ trait SudoModeRateLimitingTests
         $user = $this->generateUser(['id' => 1]);
         MultiFactorCredential::factory()->publicKey()->forUser($user)->create();
         $this->actingAs($user)->get(route('auth.sudo_mode'));
-        $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
         $this->assertSame(0, RateLimiter::attempts($throttlingKey = $this->predictableSudoRateLimitingKey($user)));
 
         $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
@@ -143,7 +143,7 @@ trait SudoModeRateLimitingTests
         Config::set('laravel-auth.webauthn.relying_party.id', 'localhost');
         $this->mockWebauthnChallenge('G0JbLLndef3a0Iy3S2sSQA8uO4SO/ze6FZMAuPI6+xI=');
         $this->actingAs($user)->get(route('auth.sudo_mode'));
-        $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
         RateLimiter::hit($throttlingKey = $this->predictableSudoRateLimitingKey($user));
         $this->assertSame(1, RateLimiter::attempts($throttlingKey));
 

--- a/src/Testing/Partials/RateLimiting/SudoModeWithoutRateLimitingTests.php
+++ b/src/Testing/Partials/RateLimiting/SudoModeWithoutRateLimitingTests.php
@@ -54,7 +54,7 @@ trait SudoModeWithoutRateLimitingTests
         $user = $this->generateUser(['id' => 1]);
         MultiFactorCredential::factory()->publicKey()->forUser($user)->create();
         $this->actingAs($user)->get(route('auth.sudo_mode'));
-        $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
         $mock = RateLimiter::partialMock();
         $mock->shouldNotReceive('tooManyAttempts');
         $mock->shouldNotReceive('availableIn');
@@ -84,7 +84,7 @@ trait SudoModeWithoutRateLimitingTests
         $user = $this->generateUser(['id' => 1]);
         MultiFactorCredential::factory()->publicKey()->forUser($user)->create();
         $this->actingAs($user)->get(route('auth.sudo_mode'));
-        $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
         $mock = RateLimiter::spy();
 
         $this->actingAs($user)->postJson(route('auth.sudo_mode'), [


### PR DESCRIPTION
This is a small change, but it is logical considering the package is primarily responsible for handling authentication and is not a typical package that provides additional features and operates within its own separate namespace.

At merge-time, it is expected that the App Tests will fail, but all other tests should pass.