### PR TITLE
Improve Rate Limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The recovery challenge will now be skipped when no codes have been configured ([#13](https://github.com/claudiodekker/laravel-auth/pull/13))
+- The Session keys now use the `auth` namespace instead of `laravel-auth::` ([#15](https://github.com/claudiodekker/laravel-auth/pull/15))
+- The rate limiting functionality has been overhauled to use multiple limiters ([#17](https://github.com/claudiodekker/laravel-auth/pull/17))
 
 ### Fixed
 

--- a/src/Http/Concerns/Challenges/PasswordChallenge.php
+++ b/src/Http/Concerns/Challenges/PasswordChallenge.php
@@ -41,7 +41,7 @@ trait PasswordChallenge
         if ($this->isCurrentlyRateLimited($request)) {
             $this->emitLockoutEvent($request);
 
-            return $this->sendRateLimitedResponse($request, $this->rateLimitingExpiresInSeconds($request));
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
         }
 
         if (! $this->hasValidPassword($request)) {

--- a/src/Http/Concerns/Challenges/PublicKeyChallenge.php
+++ b/src/Http/Concerns/Challenges/PublicKeyChallenge.php
@@ -96,7 +96,7 @@ trait PublicKeyChallenge
         if ($this->isCurrentlyRateLimited($request)) {
             $this->emitLockoutEvent($request);
 
-            return $this->sendRateLimitedResponse($request, $this->rateLimitingExpiresInSeconds($request));
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
         }
 
         if (! $options = $this->getPublicKeyChallengeOptions($request)) {

--- a/src/Http/Concerns/Challenges/TotpChallenge.php
+++ b/src/Http/Concerns/Challenges/TotpChallenge.php
@@ -46,7 +46,7 @@ trait TotpChallenge
         if ($this->isCurrentlyRateLimited($request)) {
             $this->emitLockoutEvent($request);
 
-            return $this->sendRateLimitedResponse($request, $this->rateLimitingExpiresInSeconds($request));
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
         }
 
         if (! $this->hasValidTotpCode($request)) {

--- a/src/Http/Concerns/InteractsWithRateLimiting.php
+++ b/src/Http/Concerns/InteractsWithRateLimiting.php
@@ -2,18 +2,23 @@
 
 namespace ClaudioDekker\LaravelAuth\Http\Concerns;
 
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\RateLimiter;
 
 trait InteractsWithRateLimiting
 {
     /**
-     * Get the rate limiting throttle key for the request.
+     * Prepare the identifier used to track the rate limiting state.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  string  $key
      * @return string
      */
-    abstract protected function throttleKey(Request $request): string;
+    protected function throttleKey(string $key): string
+    {
+        return "auth::$key";
+    }
 
     /**
      * Sends a response indicating that the requests have been rate limited.
@@ -25,13 +30,17 @@ trait InteractsWithRateLimiting
     abstract protected function sendRateLimitedResponse(Request $request, int $availableInSeconds);
 
     /**
-     * The number of requests per minute that aren't rate limited.
+     * Determine the rate limits that apply to the request.
      *
-     * @return int
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
      */
-    protected function maxAttempts(): int
+    protected function rateLimits(Request $request): array
     {
-        return 5;
+        return [
+            Limit::perMinute(250),
+            Limit::perMinute(5)->by('ip::'.$request->ip()),
+        ];
     }
 
     /**
@@ -42,7 +51,9 @@ trait InteractsWithRateLimiting
      */
     protected function isCurrentlyRateLimited(Request $request): bool
     {
-        return RateLimiter::tooManyAttempts($this->throttleKey($request), $this->maxAttempts());
+        return Collection::make($this->rateLimits($request))->contains(function (Limit $limit) {
+            return RateLimiter::tooManyAttempts($this->throttleKey($limit->key), $limit->maxAttempts);
+        });
     }
 
     /**
@@ -53,7 +64,8 @@ trait InteractsWithRateLimiting
      */
     protected function rateLimitExpiresInSeconds(Request $request): int
     {
-        return RateLimiter::availableIn($this->throttleKey($request));
+        return Collection::make($this->rateLimits($request))
+            ->max(fn (Limit $limit) => RateLimiter::availableIn($this->throttleKey($limit->key)));
     }
 
     /**
@@ -64,7 +76,9 @@ trait InteractsWithRateLimiting
      */
     protected function incrementRateLimitingCounter(Request $request): void
     {
-        RateLimiter::hit($this->throttleKey($request));
+        Collection::make($this->rateLimits($request))->each(function (Limit $limit) {
+            RateLimiter::hit($this->throttleKey($limit->key), $limit->decayMinutes * 60);
+        });
     }
 
     /**
@@ -75,6 +89,8 @@ trait InteractsWithRateLimiting
      */
     protected function resetRateLimitingCounter(Request $request): void
     {
-        RateLimiter::clear($this->throttleKey($request));
+        Collection::make($this->rateLimits($request))
+            ->filter(fn (Limit $limit) => $limit->key)
+            ->each(fn (Limit $limit) => RateLimiter::clear($this->throttleKey($limit->key)));
     }
 }

--- a/src/Http/Concerns/InteractsWithRateLimiting.php
+++ b/src/Http/Concerns/InteractsWithRateLimiting.php
@@ -51,7 +51,7 @@ trait InteractsWithRateLimiting
      * @param  \Illuminate\Http\Request  $request
      * @return int
      */
-    protected function rateLimitingExpiresInSeconds(Request $request): int
+    protected function rateLimitExpiresInSeconds(Request $request): int
     {
         return RateLimiter::availableIn($this->throttleKey($request));
     }

--- a/src/Http/Concerns/Login/PasskeyBasedAuthentication.php
+++ b/src/Http/Concerns/Login/PasskeyBasedAuthentication.php
@@ -55,7 +55,7 @@ trait PasskeyBasedAuthentication
         if ($this->isCurrentlyRateLimited($request)) {
             $this->emitLockoutEvent($request);
 
-            return $this->sendRateLimitedResponse($request, $this->rateLimitingExpiresInSeconds($request));
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
         }
 
         if (! $options = $this->getPasskeyAuthenticationOptions($request)) {

--- a/src/Http/Concerns/Login/PasswordBasedAuthentication.php
+++ b/src/Http/Concerns/Login/PasswordBasedAuthentication.php
@@ -37,7 +37,7 @@ trait PasswordBasedAuthentication
         if ($this->isCurrentlyRateLimited($request)) {
             $this->emitLockoutEvent($request);
 
-            return $this->sendRateLimitedResponse($request, $this->rateLimitingExpiresInSeconds($request));
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
         }
 
         if (! $user = $this->validatePasswordBasedCredentials($request)) {

--- a/src/Http/Concerns/Login/PasswordBasedAuthentication.php
+++ b/src/Http/Concerns/Login/PasswordBasedAuthentication.php
@@ -153,7 +153,6 @@ trait PasswordBasedAuthentication
     {
         $request->session()->put('auth.mfa.intended_location', $this->intendedLocation($request));
         $request->session()->put('auth.mfa.remember', $this->isRememberingUser($request));
-        $request->session()->put('auth.mfa.throttle_key', $this->throttleKey($request));
         $request->session()->put('auth.mfa.user_id', $user->getAuthIdentifier());
     }
 

--- a/src/Http/Controllers/AccountRecoveryRequestController.php
+++ b/src/Http/Controllers/AccountRecoveryRequestController.php
@@ -82,7 +82,7 @@ abstract class AccountRecoveryRequestController
         if ($this->isCurrentlyRateLimited($request)) {
             $this->emitLockoutEvent($request);
 
-            return $this->sendRateLimitedResponse($request, $this->rateLimitingExpiresInSeconds($request));
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
         }
 
         $this->incrementRateLimitingCounter($request);

--- a/src/Http/Controllers/AccountRecoveryRequestController.php
+++ b/src/Http/Controllers/AccountRecoveryRequestController.php
@@ -9,7 +9,6 @@ use ClaudioDekker\LaravelAuth\Notifications\AccountRecoveryNotification;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
-use Illuminate\Support\Str;
 
 abstract class AccountRecoveryRequestController
 {
@@ -162,16 +161,5 @@ abstract class AccountRecoveryRequestController
     protected function sendRecoveryLinkNotification(Request $request, mixed $user, string $token): void
     {
         $user->notify(new AccountRecoveryNotification($token));
-    }
-
-    /**
-     * Get the rate limiting throttle key for the request.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return string
-     */
-    protected function throttleKey(Request $request): string
-    {
-        return Str::lower('account-recovery|'.$request->ip());
     }
 }

--- a/src/Http/Controllers/Challenges/AccountRecoveryChallengeController.php
+++ b/src/Http/Controllers/Challenges/AccountRecoveryChallengeController.php
@@ -106,7 +106,7 @@ abstract class AccountRecoveryChallengeController
         if ($this->isCurrentlyRateLimited($request)) {
             $this->emitLockoutEvent($request);
 
-            return $this->sendRateLimitedResponse($request, $this->rateLimitingExpiresInSeconds($request));
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
         }
 
         if (! $user = $this->resolveUser($request)) {

--- a/src/Http/Controllers/Challenges/AccountRecoveryChallengeController.php
+++ b/src/Http/Controllers/Challenges/AccountRecoveryChallengeController.php
@@ -14,7 +14,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Password;
-use Illuminate\Support\Str;
 
 abstract class AccountRecoveryChallengeController
 {
@@ -273,16 +272,5 @@ abstract class AccountRecoveryChallengeController
     protected function emitAccountRecoveryFailedEvent(Request $request, Authenticatable $user): void
     {
         Event::dispatch(new AccountRecoveryFailed($request, $user));
-    }
-
-    /**
-     * Get the rate limiting throttle key for the request.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return string
-     */
-    protected function throttleKey(Request $request): string
-    {
-        return Str::lower('account-recovery-challenge|'.$request->ip());
     }
 }

--- a/src/Testing/Helpers.php
+++ b/src/Testing/Helpers.php
@@ -10,11 +10,11 @@ use ClaudioDekker\LaravelAuth\Methods\WebAuthn\SpomkyWebAuthn;
 use ClaudioDekker\LaravelAuth\Specifications\WebAuthn\Dictionaries\PublicKeyCredentialCreationOptions;
 use ClaudioDekker\LaravelAuth\Specifications\WebAuthn\Dictionaries\PublicKeyCredentialRequestOptions;
 use ClaudioDekker\LaravelAuth\Specifications\WebAuthn\Dictionaries\PublicKeyCredentialUserEntity;
-use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
@@ -22,17 +22,16 @@ use Mockery\MockInterface;
 
 trait Helpers
 {
-    protected function predictableRateLimitingKey(Authenticatable $user = null): string
+    protected function hitRateLimiter(int $times, string $key): void
     {
-        $username = $user->{$this->usernameField()} ?? $this->defaultUsername();
-        $ipAddress = '127.0.0.1';
-
-        return "$username|$ipAddress";
+        foreach (range(1, $times) as $i) {
+            RateLimiter::hit("auth::$key");
+        }
     }
 
-    protected function predictableSudoRateLimitingKey(Authenticatable $user): string
+    protected function getRateLimitAttempts($key): int
     {
-        return $user->getAuthIdentifier().'|127.0.0.1|sudo';
+        return RateLimiter::attempts("auth::$key");
     }
 
     protected function generateUser($overrides = []): User
@@ -114,7 +113,6 @@ trait Helpers
         }), 'Authenticated session cookie found.');
 
         $response->assertSessionHas('auth.mfa.user_id', $user->id);
-        $response->assertSessionHas('auth.mfa.throttle_key', $this->predictableRateLimitingKey($user));
     }
 
     protected function assertHasRememberCookie(TestResponse $response, $user): void

--- a/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingPublicKeyCredentialTests.php
+++ b/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingPublicKeyCredentialTests.php
@@ -229,7 +229,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
     /** @test */
     public function it_automatically_enables_sudo_mode_when_the_user_completes_the_multi_factor_challenge_using_a_public_key_credential(): void
     {
-        Carbon::setTestNow('2021-01-01 00:00:00');
+        Carbon::setTestNow(now());
         Event::fake([Authenticated::class, MultiFactorChallengeFailed::class]);
         $user = $this->generateUser(['id' => 1]);
         $credential = MultiFactorCredential::factory()->publicKey()->forUser($user)->create([

--- a/src/Testing/Partials/Challenges/Recovery/ViewAccountRecoveryChallengePageTests.php
+++ b/src/Testing/Partials/Challenges/Recovery/ViewAccountRecoveryChallengePageTests.php
@@ -116,7 +116,7 @@ trait ViewAccountRecoveryChallengePageTests
     /** @test */
     public function the_account_recovery_challenge_page_cannot_be_viewed_when_the_recovery_token_has_expired(): void
     {
-        Carbon::setTestNow('2022-01-01 00:00:00');
+        Carbon::setTestNow(now());
         $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $token = Password::getRepository()->create($user);
         Carbon::setTestNow(now()->addHour()->addSecond());

--- a/src/Testing/Partials/RateLimiting/LoginRateLimitingTests.php
+++ b/src/Testing/Partials/RateLimiting/LoginRateLimitingTests.php
@@ -6,44 +6,93 @@ use App\Providers\RouteServiceProvider;
 use ClaudioDekker\LaravelAuth\Events\Authenticated;
 use ClaudioDekker\LaravelAuth\Events\AuthenticationFailed;
 use ClaudioDekker\LaravelAuth\Events\MultiFactorChallenged;
-use ClaudioDekker\LaravelAuth\LaravelAuth;
 use ClaudioDekker\LaravelAuth\MultiFactorCredential;
 use Illuminate\Auth\Events\Lockout;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Validation\ValidationException;
 
 trait LoginRateLimitingTests
 {
     /** @test */
-    public function password_based_authentication_requests_are_rate_limited_after_too_many_failed_attempts(): void
+    public function password_based_authentication_requests_are_rate_limited_after_too_many_globally_failed_attempts(): void
     {
+        Carbon::setTestNow(now());
         Event::fake([Lockout::class, Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
-        $mock = RateLimiter::partialMock();
-        $mock->shouldReceive('tooManyAttempts')->once()->withSomeOfArgs($this->predictableRateLimitingKey())->andReturn(true);
-        $mock->shouldReceive('availableIn')->once()->andReturn(75);
+        $this->hitRateLimiter(250, '');
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
-        $this->assertSame([$this->usernameField() => ['Too many login attempts. Please try again in 75 seconds.']], $response->exception->errors());
+        $this->assertSame([$this->usernameField() => [__('laravel-auth::auth.throttle', ['seconds' => 60])]], $response->exception->errors());
         $this->assertGuest();
         Event::assertDispatched(Lockout::class, fn (Lockout $event) => $event->request === request());
         Event::assertNotDispatched(Authenticated::class);
         Event::assertNotDispatched(AuthenticationFailed::class);
         Event::assertNotDispatched(MultiFactorChallenged::class);
+        Carbon::setTestNow();
     }
 
     /** @test */
-    public function it_increments_the_rate_limiting_attempts_when_password_based_authentication_fails(): void
+    public function password_based_authentication_requests_are_rate_limited_after_too_many_failed_attempts_from_one_ip_address(): void
+    {
+        Carbon::setTestNow(now());
+        Event::fake([Lockout::class, Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
+        $this->hitRateLimiter(5, 'ip::127.0.0.1');
+
+        $responseA = $this->submitPasswordBasedLoginAttempt();
+
+        $this->assertInstanceOf(ValidationException::class, $responseA->exception);
+        $this->assertSame([$this->usernameField() => [__('laravel-auth::auth.throttle', ['seconds' => 60])]], $responseA->exception->errors());
+        $this->assertGuest();
+        Event::assertDispatched(Lockout::class, fn (Lockout $event) => $event->request === request());
+        Event::assertNotDispatched(Authenticated::class);
+        Event::assertNotDispatched(AuthenticationFailed::class);
+        Event::assertNotDispatched(MultiFactorChallenged::class);
+
+        $responseB = $this->submitPasswordBasedLoginAttempt([$this->usernameField() => $this->nonExistentUsername()]);
+        $this->assertInstanceOf(ValidationException::class, $responseB->exception);
+        $this->assertSame([$this->usernameField() => [__('laravel-auth::auth.throttle', ['seconds' => 60])]], $responseB->exception->errors());
+        Carbon::setTestNow();
+    }
+
+    /** @test */
+    public function password_based_authentication_requests_are_rate_limited_after_too_many_failed_attempts_for_one_username(): void
+    {
+        Carbon::setTestNow(now());
+        Event::fake([Lockout::class, Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
+        $this->hitRateLimiter(5, 'username::'.$this->defaultUsername());
+
+        $responseA = $this->submitPasswordBasedLoginAttempt();
+
+        $this->assertInstanceOf(ValidationException::class, $responseA->exception);
+        $this->assertSame([$this->usernameField() => [__('laravel-auth::auth.throttle', ['seconds' => 60])]], $responseA->exception->errors());
+        $this->assertGuest();
+        Event::assertDispatched(Lockout::class, fn (Lockout $event) => $event->request === request());
+        Event::assertNotDispatched(Authenticated::class);
+        Event::assertNotDispatched(AuthenticationFailed::class);
+        Event::assertNotDispatched(MultiFactorChallenged::class);
+
+        $responseB = $this->submitPasswordBasedLoginAttempt([$this->usernameField() => $this->nonExistentUsername()]);
+        $this->assertInstanceOf(ValidationException::class, $responseB->exception);
+        $this->assertSame([$this->usernameField() => ['These credentials do not match our records.']], $responseB->exception->errors());
+        Carbon::setTestNow();
+    }
+
+    /** @test */
+    public function it_increments_the_rate_limits_when_password_based_authentication_fails(): void
     {
         Event::fake([Lockout::class, AuthenticationFailed::class]);
-        $this->assertSame(0, RateLimiter::attempts($this->predictableRateLimitingKey()));
+        $this->assertSame(0, $this->getRateLimitAttempts(''));
+        $this->assertSame(0, $this->getRateLimitAttempts($usernameKey = 'username::'.$this->defaultUsername()));
+        $this->assertSame(0, $this->getRateLimitAttempts($ipKey = 'ip::127.0.0.1'));
 
         $this->submitPasswordBasedLoginAttempt(['password' => 'invalid']);
 
-        $this->assertSame(1, RateLimiter::attempts($this->predictableRateLimitingKey()));
+        $this->assertSame(1, $this->getRateLimitAttempts(''));
+        $this->assertSame(1, $this->getRateLimitAttempts($usernameKey));
+        $this->assertSame(1, $this->getRateLimitAttempts($ipKey));
         Event::assertDispatched(AuthenticationFailed::class);
         Event::assertNotDispatched(Lockout::class);
     }
@@ -53,42 +102,29 @@ trait LoginRateLimitingTests
     {
         Event::fake([Lockout::class, AuthenticationFailed::class]);
         $user = $this->generateUser();
-        RateLimiter::hit($throttlingKey = $this->predictableRateLimitingKey());
-        $this->assertSame(1, RateLimiter::attempts($throttlingKey));
+        $this->hitRateLimiter(1, '');
+        $this->hitRateLimiter(1, $usernameKey = 'username::'.$this->defaultUsername());
+        $this->hitRateLimiter(1, $ipKey = 'ip::127.0.0.1');
+        $this->assertSame(1, $this->getRateLimitAttempts(''));
+        $this->assertSame(1, $this->getRateLimitAttempts($usernameKey));
+        $this->assertSame(1, $this->getRateLimitAttempts($ipKey));
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
         $response->assertOk();
         $this->assertFullyAuthenticatedAs($response, $user);
-        $this->assertSame(0, RateLimiter::attempts($throttlingKey));
+        $this->assertSame(1, $this->getRateLimitAttempts(''));
+        $this->assertSame(0, $this->getRateLimitAttempts($usernameKey));
+        $this->assertSame(0, $this->getRateLimitAttempts($ipKey));
         Event::assertNothingDispatched();
     }
 
     /** @test */
-    public function it_retains_the_rate_limits_when_password_based_authentication_succeeds_partly_due_to_multi_factor_authentication(): void
+    public function passkey_based_authentication_requests_are_rate_limited_after_too_many_globally_failed_attempts(): void
     {
-        Event::fake([Lockout::class, AuthenticationFailed::class, Authenticated::class]);
-        $user = $this->generateUser();
-        LaravelAuth::multiFactorCredential()::factory()->totp()->forUser($user)->create();
-        RateLimiter::hit($throttlingKey = $this->predictableRateLimitingKey());
-        $this->assertSame(1, RateLimiter::attempts($throttlingKey));
-
-        $response = $this->submitPasswordBasedLoginAttempt();
-
-        $response->assertOk();
-        $response->assertExactJson(['redirect_url' => route('login.challenge.multi_factor')]);
-        $this->assertPartlyAuthenticatedAs($response, $user);
-        $this->assertSame(1, RateLimiter::attempts($throttlingKey));
-        Event::assertNothingDispatched();
-    }
-
-    /** @test */
-    public function passkey_based_authentication_requests_are_rate_limited_after_too_many_failed_attempts(): void
-    {
+        Carbon::setTestNow(now());
         Event::fake([Lockout::class, Authenticated::class, AuthenticationFailed::class]);
-        $mock = RateLimiter::partialMock();
-        $mock->shouldReceive('tooManyAttempts')->once()->withSomeOfArgs('|127.0.0.1')->andReturn(true);
-        $mock->shouldReceive('availableIn')->once()->andReturn(75);
+        $this->hitRateLimiter(250, '');
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -106,18 +142,51 @@ trait LoginRateLimitingTests
         ]);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
-        $this->assertSame([$this->usernameField() => ['Too many login attempts. Please try again in 75 seconds.']], $response->exception->errors());
+        $this->assertSame([$this->usernameField() => [__('laravel-auth::auth.throttle', ['seconds' => 60])]], $response->exception->errors());
         $this->assertGuest();
         Event::assertNotDispatched(Authenticated::class);
         Event::assertNotDispatched(AuthenticationFailed::class);
         Event::assertDispatched(Lockout::class, fn (Lockout $event) => $event->request === request());
+        Carbon::setTestNow();
+    }
+
+    /** @test */
+    public function passkey_based_authentication_requests_are_rate_limited_after_too_many_failed_attempts_from_one_ip_address(): void
+    {
+        Carbon::setTestNow(now());
+        Event::fake([Lockout::class, Authenticated::class, AuthenticationFailed::class]);
+        $this->hitRateLimiter(5, 'ip::127.0.0.1');
+
+        $responseA = $this->postJson(route('login'), [
+            'type' => 'passkey',
+            'credential' => [
+                'id' => 'ea2KxTIqiH6GqbKePv4rwk8XWVE',
+                'rawId' => 'ea2KxTIqiH6GqbKePv4rwk8XWVE=',
+                'response' => [
+                    'clientDataJSON' => 'eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiUjlLbm15VHhzNnpISkI3NWJoTEtndyIsIm9yaWdpbiI6Imh0dHBzOi8vYXV0aHRlc3Qud3JwLmFwcCJ9',
+                    'authenticatorData' => 'gEDJZQlzBdA4d4yB1qhuSL6J_Qix5U7E7xPSW4ls3BkdAAAAAA',
+                    'signature' => 'MEUCIQDrwdR9l4JUpyrmQet636nFtW8UMdQJebPHkaX2B/snrgIgbktsWMHzYSOAhUyrymLzuLCXIZd3wSBDb9XSRPfcs0E=',
+                    'userHandle' => 'MQ==',
+                ],
+                'type' => 'public-key',
+            ],
+        ]);
+
+        $this->assertInstanceOf(ValidationException::class, $responseA->exception);
+        $this->assertSame([$this->usernameField() => [__('laravel-auth::auth.throttle', ['seconds' => 60])]], $responseA->exception->errors());
+        $this->assertGuest();
+        Event::assertNotDispatched(Authenticated::class);
+        Event::assertNotDispatched(AuthenticationFailed::class);
+        Event::assertDispatched(Lockout::class, fn (Lockout $event) => $event->request === request());
+        Carbon::setTestNow();
     }
 
     /** @test */
     public function it_increments_the_rate_limiting_attempts_when_passkey_based_authentication_fails(): void
     {
         Event::fake([Lockout::class, AuthenticationFailed::class]);
-        $this->assertSame(0, RateLimiter::attempts('|127.0.0.1'));
+        $this->assertSame(0, $this->getRateLimitAttempts(''));
+        $this->assertSame(0, $this->getRateLimitAttempts($ipKey = 'ip::127.0.0.1'));
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
 
         $this->postJson(route('login'), [
@@ -135,7 +204,8 @@ trait LoginRateLimitingTests
             ],
         ]);
 
-        $this->assertSame(1, RateLimiter::attempts('|127.0.0.1'));
+        $this->assertSame(1, $this->getRateLimitAttempts(''));
+        $this->assertSame(1, $this->getRateLimitAttempts($ipKey));
         Event::assertDispatched(AuthenticationFailed::class);
     }
 
@@ -149,8 +219,10 @@ trait LoginRateLimitingTests
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
-        RateLimiter::hit($throttlingKey = '|127.0.0.1');
-        $this->assertSame(1, RateLimiter::attempts($throttlingKey));
+        $this->hitRateLimiter(1, '');
+        $this->hitRateLimiter(1, $ipKey = 'ip::127.0.0.1');
+        $this->assertSame(1, $this->getRateLimitAttempts(''));
+        $this->assertSame(1, $this->getRateLimitAttempts($ipKey));
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -170,7 +242,8 @@ trait LoginRateLimitingTests
         $response->assertOk();
         $response->assertExactJson(['redirect_url' => RouteServiceProvider::HOME]);
         $this->assertFullyAuthenticatedAs($response, $user);
-        $this->assertSame(0, RateLimiter::attempts($throttlingKey));
+        $this->assertSame(1, $this->getRateLimitAttempts(''));
+        $this->assertSame(0, $this->getRateLimitAttempts($ipKey));
         Event::assertNothingDispatched();
     }
 }

--- a/src/Testing/Partials/RateLimiting/SudoModeRateLimitingTests.php
+++ b/src/Testing/Partials/RateLimiting/SudoModeRateLimitingTests.php
@@ -2,36 +2,56 @@
 
 namespace ClaudioDekker\LaravelAuth\Testing\Partials\RateLimiting;
 
+use Carbon\Carbon;
 use ClaudioDekker\LaravelAuth\Events\SudoModeEnabled;
 use ClaudioDekker\LaravelAuth\Http\Middleware\EnsureSudoMode;
 use ClaudioDekker\LaravelAuth\MultiFactorCredential;
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Validation\ValidationException;
 
 trait SudoModeRateLimitingTests
 {
     /** @test */
-    public function password_based_sudo_mode_confirmation_requests_are_rate_limited_after_too_many_failed_attempts(): void
+    public function password_based_sudo_mode_confirmation_requests_are_rate_limited_after_too_many_failed_attempts_from_one_ip_address(): void
     {
+        Carbon::setTestNow(now());
         Event::fake([Lockout::class, SudoModeEnabled::class]);
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
-        $user = $this->generateUser();
-        $mock = RateLimiter::partialMock();
-        $mock->shouldReceive('tooManyAttempts')->once()->withSomeOfArgs($this->predictableSudoRateLimitingKey($user))->andReturn(true);
-        $mock->shouldReceive('availableIn')->once()->andReturn(75);
+        $user = $this->generateUser(['id' => 1]);
+        $this->hitRateLimiter(5, 'ip::127.0.0.1');
 
         $response = $this->actingAs($user)->post(route('auth.sudo_mode'), [
             'password' => 'password',
         ]);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
-        $this->assertSame(['password' => [__('laravel-auth::auth.challenge.throttle', ['seconds' => 75])]], $response->exception->errors());
+        $this->assertSame(['password' => [__('laravel-auth::auth.challenge.throttle', ['seconds' => 60])]], $response->exception->errors());
         Event::assertNotDispatched(SudoModeEnabled::class);
         Event::assertDispatched(Lockout::class, fn (Lockout $event) => $event->request === request());
+        Carbon::setTestNow();
+    }
+
+    /** @test */
+    public function password_based_sudo_mode_confirmation_requests_are_rate_limited_after_too_many_failed_attempts_from_one_account(): void
+    {
+        Carbon::setTestNow(now());
+        Event::fake([Lockout::class, SudoModeEnabled::class]);
+        Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
+        $user = $this->generateUser(['id' => 1]);
+        $this->hitRateLimiter(5, 'user_id::1');
+
+        $response = $this->actingAs($user)->post(route('auth.sudo_mode'), [
+            'password' => 'password',
+        ]);
+
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        $this->assertSame(['password' => [__('laravel-auth::auth.challenge.throttle', ['seconds' => 60])]], $response->exception->errors());
+        Event::assertNotDispatched(SudoModeEnabled::class);
+        Event::assertDispatched(Lockout::class, fn (Lockout $event) => $event->request === request());
+        Carbon::setTestNow();
     }
 
     /** @test */
@@ -39,14 +59,16 @@ trait SudoModeRateLimitingTests
     {
         Event::fake([Lockout::class, SudoModeEnabled::class]);
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
-        $user = $this->generateUser();
-        $this->assertSame(0, RateLimiter::attempts($throttlingKey = $this->predictableSudoRateLimitingKey($user)));
+        $user = $this->generateUser(['id' => 1]);
+        $this->assertSame(0, $this->getRateLimitAttempts($ipKey = 'ip::127.0.0.1'));
+        $this->assertSame(0, $this->getRateLimitAttempts($userKey = 'user_id::1'));
 
         $this->actingAs($user)->post(route('auth.sudo_mode'), [
             'password' => 'invalid-password',
         ]);
 
-        $this->assertSame(1, RateLimiter::attempts($throttlingKey));
+        $this->assertSame(1, $this->getRateLimitAttempts($ipKey));
+        $this->assertSame(1, $this->getRateLimitAttempts($userKey));
         Event::assertNothingDispatched();
     }
 
@@ -55,31 +77,31 @@ trait SudoModeRateLimitingTests
     {
         Event::fake([Lockout::class, SudoModeEnabled::class]);
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
-        $user = $this->generateUser();
-        RateLimiter::hit($throttlingKey = $this->predictableSudoRateLimitingKey($user));
-        $this->assertSame(1, RateLimiter::attempts($throttlingKey));
+        $user = $this->generateUser(['id' => 1]);
+        $this->hitRateLimiter(1, $ipKey = 'ip::127.0.0.1');
+        $this->hitRateLimiter(1, $userKey = 'user_id::1');
 
         $this->actingAs($user)->post(route('auth.sudo_mode'), [
             'password' => 'password',
         ]);
 
-        $this->assertSame(0, RateLimiter::attempts($throttlingKey));
+        $this->assertSame(0, $this->getRateLimitAttempts($ipKey));
+        $this->assertSame(0, $this->getRateLimitAttempts($userKey));
         Event::assertDispatched(SudoModeEnabled::class);
         Event::assertNotDispatched(Lockout::class);
     }
 
     /** @test */
-    public function credential_based_sudo_mode_confirmation_requests_are_rate_limited_after_too_many_failed_attempts(): void
+    public function credential_based_sudo_mode_confirmation_requests_are_rate_limited_after_too_many_failed_attempts_from_one_ip_address(): void
     {
+        Carbon::setTestNow(now());
         Event::fake([Lockout::class, SudoModeEnabled::class]);
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $user = $this->generateUser(['id' => 1]);
         MultiFactorCredential::factory()->publicKey()->forUser($user)->create();
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
-        $mock = RateLimiter::partialMock();
-        $mock->shouldReceive('tooManyAttempts')->once()->withSomeOfArgs($this->predictableSudoRateLimitingKey($user))->andReturn(true);
-        $mock->shouldReceive('availableIn')->once()->andReturn(75);
+        $this->hitRateLimiter(5, 'ip::127.0.0.1');
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -96,21 +118,57 @@ trait SudoModeRateLimitingTests
         ]);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
-        $this->assertSame(['password' => [__('laravel-auth::auth.challenge.throttle', ['seconds' => 75])]], $response->exception->errors());
+        $this->assertSame(['password' => [__('laravel-auth::auth.challenge.throttle', ['seconds' => 60])]], $response->exception->errors());
         Event::assertNotDispatched(SudoModeEnabled::class);
         Event::assertDispatched(Lockout::class, fn (Lockout $event) => $event->request === request());
+        Carbon::setTestNow();
     }
 
     /** @test */
-    public function it_increments_the_rate_limiting_attempts_when_credential_based_sudo_mode_confirmation_fails(): void
+    public function credential_based_sudo_mode_confirmation_requests_are_rate_limited_after_too_many_failed_attempts_from_one_account(): void
     {
+        Carbon::setTestNow(now());
         Event::fake([Lockout::class, SudoModeEnabled::class]);
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $user = $this->generateUser(['id' => 1]);
         MultiFactorCredential::factory()->publicKey()->forUser($user)->create();
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
-        $this->assertSame(0, RateLimiter::attempts($throttlingKey = $this->predictableSudoRateLimitingKey($user)));
+        $this->hitRateLimiter(5, 'user_id::1');
+
+        $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
+            'credential' => [
+                'id' => 'eHouz_Zi7-BmByHjJ_tx9h4a1WZsK4IzUmgGjkhyOodPGAyUqUp_B9yUkflXY3yHWsNtsrgCXQ3HjAIFUeZB-w',
+                'type' => 'public-key',
+                'rawId' => 'eHouz/Zi7+BmByHjJ/tx9h4a1WZsK4IzUmgGjkhyOodPGAyUqUp/B9yUkflXY3yHWsNtsrgCXQ3HjAIFUeZB+w==',
+                'response' => [
+                    'clientDataJSON' => 'eyJjaGFsbGVuZ2UiOiJHMEpiTExuZGVmM2EwSXkzUzJzU1FBOHVPNFNPX3plNkZaTUF1UEk2LXhJIiwiY2xpZW50RXh0ZW5zaW9ucyI6e30sImhhc2hBbGdvcml0aG0iOiJTSEEtMjU2Iiwib3JpZ2luIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6ODQ0MyIsInR5cGUiOiJ3ZWJhdXRobi5nZXQifQ',
+                    'authenticatorData' => 'SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MBAAAAew',
+                    'signature' => 'MEUCIEY/vcNkbo/LdMTfLa24ZYLlMMVMRd8zXguHBvqud9AJAiEAwCwpZpvcMaqCrwv85w/8RGiZzE+gOM61ffxmgEDeyhM=',
+                    'userHandle' => null,
+                ],
+            ],
+        ]);
+
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        $this->assertSame(['password' => [__('laravel-auth::auth.challenge.throttle', ['seconds' => 60])]], $response->exception->errors());
+        Event::assertNotDispatched(SudoModeEnabled::class);
+        Event::assertDispatched(Lockout::class, fn (Lockout $event) => $event->request === request());
+        Carbon::setTestNow();
+    }
+
+    /** @test */
+    public function it_increments_the_rate_limiting_attempts_when_credential_based_sudo_mode_confirmation_fails(): void
+    {
+        Carbon::setTestNow(now());
+        Event::fake([Lockout::class, SudoModeEnabled::class]);
+        Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
+        $user = $this->generateUser(['id' => 1]);
+        MultiFactorCredential::factory()->publicKey()->forUser($user)->create();
+        $this->actingAs($user)->get(route('auth.sudo_mode'));
+        $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
+        $this->assertSame(0, $this->getRateLimitAttempts($ipKey = 'ip::127.0.0.1'));
+        $this->assertSame(0, $this->getRateLimitAttempts($userKey = 'user_id::1'));
 
         $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -126,13 +184,16 @@ trait SudoModeRateLimitingTests
             ],
         ]);
 
-        $this->assertSame(1, RateLimiter::attempts($throttlingKey));
+        $this->assertSame(1, $this->getRateLimitAttempts($ipKey));
+        $this->assertSame(1, $this->getRateLimitAttempts($userKey));
         Event::assertNothingDispatched();
+        Carbon::setTestNow();
     }
 
     /** @test */
     public function it_resets_the_rate_limiting_attempts_when_credential_based_sudo_mode_confirmation_succeeds(): void
     {
+        Carbon::setTestNow(now());
         Event::fake([Lockout::class, SudoModeEnabled::class]);
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $user = $this->generateUser(['id' => 1]);
@@ -144,8 +205,8 @@ trait SudoModeRateLimitingTests
         $this->mockWebauthnChallenge('G0JbLLndef3a0Iy3S2sSQA8uO4SO/ze6FZMAuPI6+xI=');
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('auth.sudo_mode.public_key_challenge_request_options'));
-        RateLimiter::hit($throttlingKey = $this->predictableSudoRateLimitingKey($user));
-        $this->assertSame(1, RateLimiter::attempts($throttlingKey));
+        $this->hitRateLimiter(1, $ipKey = 'ip::127.0.0.1');
+        $this->hitRateLimiter(1, $userKey = 'user_id::1');
 
         $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -161,8 +222,10 @@ trait SudoModeRateLimitingTests
             ],
         ]);
 
-        $this->assertSame(0, RateLimiter::attempts($throttlingKey));
+        $this->assertSame(0, $this->getRateLimitAttempts($ipKey));
+        $this->assertSame(0, $this->getRateLimitAttempts($userKey));
         Event::assertDispatched(SudoModeEnabled::class);
         Event::assertNotDispatched(Lockout::class);
+        Carbon::setTestNow();
     }
 }

--- a/src/Testing/Partials/SubmitAccountRecoveryRequestTests.php
+++ b/src/Testing/Partials/SubmitAccountRecoveryRequestTests.php
@@ -86,7 +86,7 @@ trait SubmitAccountRecoveryRequestTests
     /** @test */
     public function it_only_sends_a_fresh_recovery_link_when_one_has_not_been_sent_recently(): void
     {
-        Carbon::setTestNow('2022-01-01 00:00:00');
+        Carbon::setTestNow(now());
         Notification::fake();
         $repository = Password::getRepository();
         $user = $this->generateUser();


### PR DESCRIPTION
This pull request updates the rate limiting system to allow for multiple, customizable rate limiters rather than a fixed key. This adds another layer of safety, without any downsides.

In the current implementation, when an attacker tries to brute-force a password for a specific user's account, the rate limiting is either applied based on their IP address, or based on the username/user id, but not on both. While this might seem like an acceptable and decent solution, in modern days attackers often have access to a network of bots or servers to proxy their requests through, making IP-based rate limiting alone ineffective. On the other hand, solely relying on username/user id rate limiting would allow the attacker to target other users once they are rate-limited on one. 

This PR adds the ability to add [multiple rate-limits](https://laravel.com/docs/9.x/routing#multiple-rate-limits) per request, and adjusts our implementation to have sensible defaults that incorporate both global limits, IP-based limits, as well as per-account/per-user limits.