### PR TITLE
Reduce number of workflows

### DIFF
--- a/.github/workflows/app-tests.yml
+++ b/.github/workflows/app-tests.yml
@@ -2,6 +2,9 @@ name: App Tests
 
 on:
   push:
+    branches:
+      - master
+      - '*.x'
   pull_request:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/fix-styling.yml
+++ b/.github/workflows/fix-styling.yml
@@ -1,6 +1,10 @@
 name: Check & fix styling
 
-on: push
+on:
+  push:
+    branches:
+      - master
+      - '*.x'
 
 jobs:
   pint:

--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -2,6 +2,9 @@ name: Package Tests
 
 on:
   push:
+    branches:
+      - master
+      - '*.x'
   pull_request:
 
 jobs:

--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - '*.x'
     tags:
       - '*'
 

--- a/.github/workflows/validate-generator-styling.yml
+++ b/.github/workflows/validate-generator-styling.yml
@@ -2,6 +2,9 @@ name: Validate Core Generator Styling
 
 on:
   push:
+    branches:
+      - master
+      - '*.x'
   pull_request:
 
 jobs:


### PR DESCRIPTION
Every time you do a PR from within the repo, all tests run twice: once for push and once fur pull_request.

This change will make it so that you only run the tests when a PR is open or you push on the branch `master` or `*.x` which will reduce the number of workflows by about half.

(If you create a branch `xyz` the tests will not run by itself, it will only do so after opening a PR)