### PR TITLE
Remove old monorepo builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "nunomaduro/larastan": "^2.0",
         "orchestra/testbench": "^7.0|^8.0",
         "phpunit/phpunit": "^9.5.10",
-        "roave/security-advisories": "dev-latest",
-        "symplify/monorepo-builder": "11.2.2.72"
+        "roave/security-advisories": "dev-latest"
     },
     "autoload": {
         "psr-4": {

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-use Symplify\MonorepoBuilder\Config\MBConfig;
-
-return static function (MBConfig $mbConfig): void {
-    $mbConfig->packageDirectories([__DIR__.'/packages']);
-};


### PR DESCRIPTION
I think this is handled by the workflow by danharrin and this file is not needed anymore.