### PR TITLE
Remove ext-json requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     "require": {
         "bacon/bacon-qr-code": "^2.0",
         "claudiodekker/word-generator": "^1.0",
-        "ext-json": "*",
         "laravel/framework": "^9.33|^10.0",
         "nyholm/psr7": "^1.5",
         "php": "~8.1.0|~8.2.0",

--- a/packages/bladebones/composer.json
+++ b/packages/bladebones/composer.json
@@ -24,7 +24,6 @@
     ],
     "require": {
         "php": "~8.1.0|~8.2.0",
-        "ext-json": "*",
         "laravel/framework": "^9.33|^10.0",
         "claudiodekker/laravel-auth-core": "^0.2.0"
     },

--- a/packages/core/composer.json
+++ b/packages/core/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": "~8.1.0|~8.2.0",
-        "ext-json": "*",
         "bacon/bacon-qr-code": "^2.0",
         "claudiodekker/word-generator": "^1.0",
         "laravel/framework": "^9.33|^10.0",


### PR DESCRIPTION
ext-json is always included as of PHP 8.0:
https://php.watch/versions/8.0/ext-json