### PR TITLE
Update Changelog & add changelog auto-updater

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,64 @@
+name: Update Changelog on PR Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  update-changelog:
+    name: Update Changelog
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      - name: Determine changelog section to update
+        id: sections
+        run: |
+          section=""
+          labels=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]')
+          for label in $labels; do
+            lower_label=$(echo "$label" | tr '[:upper:]' '[:lower:]')
+            case "$lower_label" in
+              enhancement|feature) section="Added"; break;;
+              bug|bugfix|fix|patch) section="Fixed"; break;;
+              change) section="Changed"; break;;
+              optimization|improvement|performance|refactor) section="Optimized"; break;;
+              deprecation|deprecated) section="Deprecated"; break;;
+              revert) section="Reverted"; break;;
+              removal) section="Removed"; break;;
+              security) section="Security"; break;;
+            esac
+          done
+
+          if [ -z "$section" ]; then
+            echo "No matching label found for changelog entry, skipping changelog update."
+            exit 0
+          else
+            echo "section=$section" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add entry to CHANGELOG.md
+        if: steps.sections.outputs.section != ''
+        uses: claudiodekker/changelog-updater@master
+        with:
+          section: "${{ steps.sections.outputs.section }}"
+          entry-text: "${{ github.event.pull_request.title }}"
+          entry-link: "${{ github.event.pull_request.html_url }}"
+
+      - name: Commit updated CHANGELOG
+        if: steps.sections.outputs.section != ''
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: ${{ github.event.pull_request.base.ref }}
+          commit_message: "Update CHANGELOG.md w/ PR #${{ github.event.pull_request.number }}"
+          file_pattern: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/claudiodekker/laravel-auth/compare/v0.2.0...HEAD)
 
+### Added
+
+- Account Security indicator ([#26](https://github.com/claudiodekker/laravel-auth/pull/26))
+- Core: Add support for pruning "claimed" users that never finish sign-up ([#27](https://github.com/claudiodekker/laravel-auth/pull/27))
+- Add docblock-level `@see`-references ([#29](https://github.com/claudiodekker/laravel-auth/pull/29))
+- Core: Skip the recovery code challenge when no codes exist ([#30](https://github.com/claudiodekker/laravel-auth/pull/30))
+
 ### Fixed
 
 - Core: Fixed timing-related test regression ([#24](https://github.com/claudiodekker/laravel-auth/pull/24))
+- Bladebones: Recovery Code must be exactly 10 characters ([#28](https://github.com/claudiodekker/laravel-auth/pull/28))
+- Core: Public Key Challenge - Update signature count ([#31](https://github.com/claudiodekker/laravel-auth/pull/31))
+
+### Changed
+
+- Improve Rate Limiting ([#32](https://github.com/claudiodekker/laravel-auth/pull/32))
+- Added Larastan & improved violations ([#36](https://github.com/claudiodekker/laravel-auth/pull/36))
+
+### Optimized
+
+- Improved dev-dependencies ([#39](https://github.com/claudiodekker/laravel-auth/pull/39))
+- Remove ext-json requirement ([#41](https://github.com/claudiodekker/laravel-auth/pull/41))
+
+### Removed
+
+- Revert model DB connection customization ([#38](https://github.com/claudiodekker/laravel-auth/pull/38))
 
 ## [v0.2.0](https://github.com/claudiodekker/laravel-auth/compare/v0.1.2...v0.2.0) - 2023-04-03
 


### PR DESCRIPTION
This PR adds https://github.com/claudiodekker/changelog-updater into the repository, as to automatically update the CHANGELOG.md file when changes are detected.

While I've already updated the CHANGELOG.md file manually to make sure it's in-sync with the changes made recently, I'll still be tagging this as an Optimisation change, so the auto-updater can re-format the CHANGELOG.md file for consistency if needed.