### PR TITLE
Local dev: Allow marking origins as "potentially trustworthy"

### DIFF
--- a/packages/core/config/laravel-auth.php
+++ b/packages/core/config/laravel-auth.php
@@ -45,6 +45,16 @@ return [
         ],
 
         /**
+         * These option is only intended for development purposes, and should not be used in production environment.
+         * It is important for scenarios where you want to test the WebAuthn flow on localhost, but you don't have
+         * a valid SSL certificate. In this case, you can use this option to bypass the SSL requirement.
+         */
+        'secured_relying_parties' => 
+            env('AUTH_RP_ID', Str::after(config('app.url'), '://')) === 'localhost' && env('APP_ENV') === 'local'
+                ? ['localhost']
+                : [],
+
+        /**
          * These options are used to configure the preferences for multi-factor authentication.
          *
          * In contrast to Passkeys (or client-side discoverable credentials), the credentials used during

--- a/packages/core/config/laravel-auth.php
+++ b/packages/core/config/laravel-auth.php
@@ -42,17 +42,21 @@ return [
              * The name of your application.
              */
             'name' => env('AUTH_RP_NAME', config('app.name', 'Laravel')),
-        ],
 
-        /**
-         * These option is only intended for development purposes, and should not be used in production environment.
-         * It is important for scenarios where you want to test the WebAuthn flow on localhost, but you don't have
-         * a valid SSL certificate. In this case, you can use this option to bypass the SSL requirement.
-         */
-        'secured_relying_parties' => 
-            env('AUTH_RP_ID', Str::after(config('app.url'), '://')) === 'localhost' && env('APP_ENV') === 'local'
-                ? ['localhost']
-                : [],
+            /**
+             * This setting allows you to mark specific origins as "potentially trustworthy", enabling you
+             * to bypass strict requirements for HTTPS and authentication. This can be helpful on local
+             * environments where HTTPS may not be accessible. This feature is only available when
+             * the APP_DEBUG option is set to true, as it should NOT be used in production.
+             *
+             * @link https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin
+             * @link https://www.w3.org/TR/secure-contexts/#localhost
+             */
+            'potentially_trustworthy_origins' => [
+                'localhost',
+            ],
+
+        ],
 
         /**
          * These options are used to configure the preferences for multi-factor authentication.

--- a/packages/core/src/Methods/WebAuthn/SpomkyWebAuthn.php
+++ b/packages/core/src/Methods/WebAuthn/SpomkyWebAuthn.php
@@ -123,7 +123,12 @@ class SpomkyWebAuthn implements WebAuthnContract
         );
 
         try {
-            $publicKeyCredentialSource = $validator->check($authenticatorResponse, $creationOptions, $request);
+            $publicKeyCredentialSource = $validator->check(
+                $authenticatorResponse,
+                $creationOptions,
+                $request,
+                Config::get('laravel-auth.webauthn.secured_relying_parties')
+            );
         } catch (Throwable $exception) {
             throw new InvalidPublicKeyCredentialException($exception->getMessage(), $exception->getCode(), $exception);
         }
@@ -206,6 +211,7 @@ class SpomkyWebAuthn implements WebAuthnContract
                 $requestOptions,
                 $request,
                 $user?->id(),
+                Config::get('laravel-auth.webauthn.secured_relying_parties')
             );
         } catch (Throwable $exception) {
             throw new InvalidPublicKeyCredentialException($exception->getMessage(), $exception->getCode(), $exception);

--- a/packages/core/src/Testing/Helpers.php
+++ b/packages/core/src/Testing/Helpers.php
@@ -152,10 +152,32 @@ trait Helpers
         return App::make(WebAuthnContract::class)->generatePasskeyCreationOptions($userEntity);
     }
 
+    protected function mockPasskeyCreationOptionsTwo(User $user): PublicKeyCredentialCreationOptions
+    {
+        Config::set('laravel-auth.webauthn.relying_party.id', 'localhost');
+        $this->mockWebauthnChallenge('ImJ9UcKWlxQeb8V4MxSrrg');
+
+        $userEntity = new PublicKeyCredentialUserEntity(
+            $user->id,
+            $user->{$this->usernameField()},
+            $user->name
+        );
+
+        return App::make(WebAuthnContract::class)->generatePasskeyCreationOptions($userEntity);
+    }
+
     protected function mockPasskeyRequestOptions(): PublicKeyCredentialRequestOptions
     {
         Config::set('laravel-auth.webauthn.relying_party.id', 'authtest.wrp.app');
         $this->mockWebauthnChallenge('R9KnmyTxs6zHJB75bhLKgw');
+
+        return App::make(WebAuthnContract::class)->generatePasskeyRequestOptions();
+    }
+
+    protected function mockPasskeyRequestOptionsTwo(): PublicKeyCredentialRequestOptions
+    {
+        Config::set('laravel-auth.webauthn.relying_party.id', 'localhost');
+        $this->mockWebauthnChallenge('ImJ9UcKWlxQeb8V4MxSrrg');
 
         return App::make(WebAuthnContract::class)->generatePasskeyRequestOptions();
     }

--- a/packages/core/src/Testing/Partials/SubmitPasskeyBasedAuthenticationTests.php
+++ b/packages/core/src/Testing/Partials/SubmitPasskeyBasedAuthenticationTests.php
@@ -10,6 +10,7 @@ use ClaudioDekker\LaravelAuth\Events\SudoModeEnabled;
 use ClaudioDekker\LaravelAuth\Http\Middleware\EnsureSudoMode;
 use ClaudioDekker\LaravelAuth\MultiFactorCredential;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Session;
@@ -117,6 +118,76 @@ trait SubmitPasskeyBasedAuthenticationTests
     }
 
     /** @test */
+    public function it_fails_to_authenticate_using_a_passkey_when_the_credential_is_malformed(): void
+    {
+        Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
+        $user = $this->generateUser(['id' => 1, 'has_password' => false]);
+        MultiFactorCredential::factory()->publicKey()->forUser($user)->create([
+            'id' => 'public-key-ea2KxTIqiH6GqbKePv4rwk8XWVE',
+            'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
+        ]);
+        Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
+
+        $response = $this->postJson(route('login'), [
+            'type' => 'passkey',
+            'credential' => [
+                'id' => 'ea2KxTIqiH6GqbKePv4rwk8XWVE',
+                'rawId' => 'ea2KxTIqiH6GqbKePv4rwk8XWVE=',
+                'response' => [
+                    'clientDataJSON' => 'eyJ0eXBlIjoid2VV0IiwiY2hhbGxlbmdlIjoiUjlLbm15VHhzNnpIWJoTEtndyIsIm9yaWdpbiI6Imh0dHBzOi8vYXV0aHRlc3Qud3JwLmFwcCJ9',
+                    'authenticatorData' => 'gZQlzBdA4d4yB1uSL6J_Qix5U7E7xPSW4ls3BkdAAAAAA',
+                    'signature' => 'MEUCIQDrwdR9l4JUpyrmQ6JebPHkaX2B/snrgIgbktsWMHzYSOAhUyrymLzuLCXIZd3wSBDb9XSRPfcs0E=',
+                    'userHandle' => 'MQ==',
+                ],
+                'type' => 'public-key',
+            ],
+        ]);
+
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        $this->assertSame([$this->usernameField() => [__('laravel-auth::auth.failed')]], $response->exception->errors());
+        $this->assertTrue(Session::has('auth.login.passkey_authentication_options'));
+        $this->assertGuest();
+        Event::assertNotDispatched(Authenticated::class);
+        Event::assertNotDispatched(MultiFactorChallenged::class);
+        Event::assertDispatched(AuthenticationFailed::class, fn (AuthenticationFailed $event) => $event->username === null);
+    }
+
+    /** @test */
+    public function it_fails_to_authenticate_using_a_passkey_when_the_challenge_does_not_match(): void
+    {
+        Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
+        $user = $this->generateUser(['id' => 1, 'has_password' => false]);
+        MultiFactorCredential::factory()->publicKey()->forUser($user)->create([
+            'id' => 'public-key-ea2KxTIqiH6GqbKePv4rwk8XWVE',
+            'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
+        ]);
+        Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptionsTwo()));
+
+        $response = $this->postJson(route('login'), [
+            'type' => 'passkey',
+            'credential' => [
+                'id' => 'ea2KxTIqiH6GqbKePv4rwk8XWVE',
+                'rawId' => 'ea2KxTIqiH6GqbKePv4rwk8XWVE=',
+                'response' => [
+                    'clientDataJSON' => 'eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiUjlLbm15VHhzNnpISkI3NWJoTEtndyIsIm9yaWdpbiI6Imh0dHBzOi8vYXV0aHRlc3Qud3JwLmFwcCJ9',
+                    'authenticatorData' => 'gEDJZQlzBdA4d4yB1qhuSL6J_Qix5U7E7xPSW4ls3BkdAAAAAA',
+                    'signature' => 'MEUCIQDrwdR9l4JUpyrmQet636nFtW8UMdQJebPHkaX2B/snrgIgbktsWMHzYSOAhUyrymLzuLCXIZd3wSBDb9XSRPfcs0E=',
+                    'userHandle' => 'MQ==',
+                ],
+                'type' => 'public-key',
+            ],
+        ]);
+
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        $this->assertSame([$this->usernameField() => [__('laravel-auth::auth.failed')]], $response->exception->errors());
+        $this->assertTrue(Session::has('auth.login.passkey_authentication_options'));
+        $this->assertGuest();
+        Event::assertNotDispatched(Authenticated::class);
+        Event::assertNotDispatched(MultiFactorChallenged::class);
+        Event::assertDispatched(AuthenticationFailed::class, fn (AuthenticationFailed $event) => $event->username === null);
+    }
+
+    /** @test */
     public function it_fails_to_authenticate_using_a_passkey_when_an_unknown_credential_was_provided(): void
     {
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
@@ -183,26 +254,103 @@ trait SubmitPasskeyBasedAuthenticationTests
     }
 
     /** @test */
-    public function it_fails_to_authenticate_using_a_passkey_when_the_credential_is_malformed(): void
+    public function it_authenticates_the_user_using_a_passkey_on_an_insecure_origin_that_has_been_manually_marked_as_trustworthy(): void
     {
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
+        Config::set('app.debug', true);
+        Config::set('laravel-auth.webauthn.relying_party.potentially_trustworthy_origins', ['localhost']);
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         MultiFactorCredential::factory()->publicKey()->forUser($user)->create([
-            'id' => 'public-key-ea2KxTIqiH6GqbKePv4rwk8XWVE',
-            'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
+            'id' => 'public-key-ID_CFbjp7mfDuI4zwEe-49_g1-8',
+            'secret' => '{"id":"ID\/CFbjp7mfDuI4zwEe+49\/g1+8=","publicKey":"pQECAyYgASFYIFZSx3fc0szMDz38Eu4ZBWjeAQMP0dWR\/D+Dy3RA1tktIlggJzLmQt5ydTQ6PXRF4GFCgWyXJBT0giypbK0wducMmW4=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
-        Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
+        Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptionsTwo()));
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
             'credential' => [
-                'id' => 'ea2KxTIqiH6GqbKePv4rwk8XWVE',
-                'rawId' => 'ea2KxTIqiH6GqbKePv4rwk8XWVE=',
+                'id' => 'ID_CFbjp7mfDuI4zwEe-49_g1-8',
+                'rawId' => 'ID_CFbjp7mfDuI4zwEe-49_g1-8',
                 'response' => [
-                    'clientDataJSON' => 'eyJ0eXBlIjoid2VV0IiwiY2hhbGxlbmdlIjoiUjlLbm15VHhzNnpIWJoTEtndyIsIm9yaWdpbiI6Imh0dHBzOi8vYXV0aHRlc3Qud3JwLmFwcCJ9',
-                    'authenticatorData' => 'gZQlzBdA4d4yB1uSL6J_Qix5U7E7xPSW4ls3BkdAAAAAA',
-                    'signature' => 'MEUCIQDrwdR9l4JUpyrmQ6JebPHkaX2B/snrgIgbktsWMHzYSOAhUyrymLzuLCXIZd3wSBDb9XSRPfcs0E=',
-                    'userHandle' => 'MQ==',
+                    'clientDataJSON' => 'eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiSW1KOVVjS1dseFFlYjhWNE14U3JyZyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3QifQ',
+                    'authenticatorData' => 'SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MdAAAAAA',
+                    'signature' => 'MEUCIQC3KKOoro_3A8ssdIVA8sSnnbI3y_d-a_I_8eTSPgh23AIgWajRc28MIl89U_9uD-cLLPDDs8UpLo187_BC-YHpCTE',
+                    'userHandle' => 'MQ',
+                ],
+                'type' => 'public-key',
+            ],
+        ]);
+
+        $response->assertOk();
+        $response->assertExactJson(['redirect_url' => RouteServiceProvider::HOME]);
+        $this->assertFalse(Session::has('auth.login.passkey_authentication_options'));
+        $this->assertFullyAuthenticatedAs($response, $user);
+        $this->assertMissingRememberCookie($response, $user);
+        Event::assertNotDispatched(AuthenticationFailed::class);
+        Event::assertNotDispatched(MultiFactorChallenged::class);
+        Event::assertDispatched(Authenticated::class, fn (Authenticated $event) => $event->user->is($user));
+    }
+
+    /** @test */
+    public function it_fails_to_authenticate_using_a_passkey_on_an_insecure_origin_that_has_been_manually_marked_as_trustworthy_when_debug_is_disabled(): void
+    {
+        Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
+        Config::set('app.debug', false);
+        Config::set('laravel-auth.webauthn.relying_party.potentially_trustworthy_origins', ['localhost']);
+        $user = $this->generateUser(['id' => 1, 'has_password' => false]);
+        MultiFactorCredential::factory()->publicKey()->forUser($user)->create([
+            'id' => 'public-key-ID_CFbjp7mfDuI4zwEe-49_g1-8',
+            'secret' => '{"id":"ID\/CFbjp7mfDuI4zwEe+49\/g1+8=","publicKey":"pQECAyYgASFYIFZSx3fc0szMDz38Eu4ZBWjeAQMP0dWR\/D+Dy3RA1tktIlggJzLmQt5ydTQ6PXRF4GFCgWyXJBT0giypbK0wducMmW4=","signCount":0,"userHandle":"1","transports":[]}',
+        ]);
+        Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptionsTwo()));
+
+        $response = $this->postJson(route('login'), [
+            'type' => 'passkey',
+            'credential' => [
+                'id' => 'ID_CFbjp7mfDuI4zwEe-49_g1-8',
+                'rawId' => 'ID_CFbjp7mfDuI4zwEe-49_g1-8',
+                'response' => [
+                    'clientDataJSON' => 'eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiSW1KOVVjS1dseFFlYjhWNE14U3JyZyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3QifQ',
+                    'authenticatorData' => 'SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MdAAAAAA',
+                    'signature' => 'MEUCIQC3KKOoro_3A8ssdIVA8sSnnbI3y_d-a_I_8eTSPgh23AIgWajRc28MIl89U_9uD-cLLPDDs8UpLo187_BC-YHpCTE',
+                    'userHandle' => 'MQ',
+                ],
+                'type' => 'public-key',
+            ],
+        ]);
+
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        $this->assertSame([$this->usernameField() => [__('laravel-auth::auth.failed')]], $response->exception->errors());
+        $this->assertTrue(Session::has('auth.login.passkey_authentication_options'));
+        $this->assertGuest();
+        Event::assertNotDispatched(Authenticated::class);
+        Event::assertNotDispatched(MultiFactorChallenged::class);
+        Event::assertDispatched(AuthenticationFailed::class, fn (AuthenticationFailed $event) => $event->username === null);
+    }
+
+    /** @test */
+    public function it_fails_to_authenticate_using_a_passkey_on_an_insecure_origin_when_it_has_not_been_manually_marked_as_trustworthy(): void
+    {
+        Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
+        Config::set('app.debug', true);
+        Config::set('laravel-auth.webauthn.relying_party.potentially_trustworthy_origins', ['foo.com']);
+        $user = $this->generateUser(['id' => 1, 'has_password' => false]);
+        MultiFactorCredential::factory()->publicKey()->forUser($user)->create([
+            'id' => 'public-key-ID_CFbjp7mfDuI4zwEe-49_g1-8',
+            'secret' => '{"id":"ID\/CFbjp7mfDuI4zwEe+49\/g1+8=","publicKey":"pQECAyYgASFYIFZSx3fc0szMDz38Eu4ZBWjeAQMP0dWR\/D+Dy3RA1tktIlggJzLmQt5ydTQ6PXRF4GFCgWyXJBT0giypbK0wducMmW4=","signCount":0,"userHandle":"1","transports":[]}',
+        ]);
+        Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptionsTwo()));
+
+        $response = $this->postJson(route('login'), [
+            'type' => 'passkey',
+            'credential' => [
+                'id' => 'ID_CFbjp7mfDuI4zwEe-49_g1-8',
+                'rawId' => 'ID_CFbjp7mfDuI4zwEe-49_g1-8',
+                'response' => [
+                    'clientDataJSON' => 'eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiSW1KOVVjS1dseFFlYjhWNE14U3JyZyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3QifQ',
+                    'authenticatorData' => 'SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MdAAAAAA',
+                    'signature' => 'MEUCIQC3KKOoro_3A8ssdIVA8sSnnbI3y_d-a_I_8eTSPgh23AIgWajRc28MIl89U_9uD-cLLPDDs8UpLo187_BC-YHpCTE',
+                    'userHandle' => 'MQ',
                 ],
                 'type' => 'public-key',
             ],

--- a/packages/core/src/Testing/Partials/SubmitPasskeyBasedRegistrationTests.php
+++ b/packages/core/src/Testing/Partials/SubmitPasskeyBasedRegistrationTests.php
@@ -324,6 +324,106 @@ trait SubmitPasskeyBasedRegistrationTests
     }
 
     /** @test */
+    public function it_confirms_passkey_based_registration_on_an_insecure_origin_that_has_been_manually_marked_as_trustworthy(): void
+    {
+        Event::fake(Registered::class);
+        Config::set('app.debug', true);
+        Config::set('laravel-auth.webauthn.relying_party.potentially_trustworthy_origins', ['localhost']);
+        $user = $this->generateUser(['id' => 1, 'has_password' => false]);
+        $options = $this->mockPasskeyCreationOptionsTwo($user);
+        Session::put('auth.register.passkey_creation_options', serialize($options));
+
+        $response = $this->postJson(route('register'), [
+            'type' => 'passkey',
+            'credential' => [
+                'id' => 'ID_CFbjp7mfDuI4zwEe-49_g1-8',
+                'rawId' => 'ID_CFbjp7mfDuI4zwEe-49_g1-8',
+                'response' => [
+                    'clientDataJSON' => 'eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiSW1KOVVjS1dseFFlYjhWNE14U3JyZyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3QifQ',
+                    'attestationObject' => 'o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YViYSZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NdAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCA_whW46e5nw7iOM8BHvuPf4NfvpQECAyYgASFYIFZSx3fc0szMDz38Eu4ZBWjeAQMP0dWR_D-Dy3RA1tktIlggJzLmQt5ydTQ6PXRF4GFCgWyXJBT0giypbK0wducMmW4',
+                ],
+                'type' => 'public-key',
+            ],
+        ]);
+
+        $response->assertCreated();
+        $response->assertExactJson(['redirect_url' => RouteServiceProvider::HOME]);
+        $this->assertAuthenticatedAs($user);
+        $this->assertFalse(Session::has('auth.register.passkey_creation_options'));
+        $this->assertCount(1, $credentials = MultiFactorCredential::all());
+        tap($credentials->first(), function (MultiFactorCredential $key) use ($user) {
+            $this->assertSame('public-key-ID_CFbjp7mfDuI4zwEe-49_g1-8', $key->id);
+            $this->assertSame($user->id, $key->user_id);
+            $this->assertEquals(CredentialType::PUBLIC_KEY, $key->type);
+            $this->assertEquals('User Passkey', $key->name);
+            $this->assertSame('{"id":"ID\/CFbjp7mfDuI4zwEe+49\/g1+8=","publicKey":"pQECAyYgASFYIFZSx3fc0szMDz38Eu4ZBWjeAQMP0dWR\/D+Dy3RA1tktIlggJzLmQt5ydTQ6PXRF4GFCgWyXJBT0giypbK0wducMmW4=","signCount":0,"userHandle":"1","transports":[]}', $key->secret);
+        });
+        Event::assertDispatched(Registered::class, fn (Registered $event) => $event->user->is($user));
+    }
+
+    /** @test */
+    public function it_cannot_confirm_passkey_based_registration_on_an_insecure_origin_that_has_been_manually_marked_as_trustworthy_when_debug_is_disabled(): void
+    {
+        Event::fake(Registered::class);
+        Config::set('app.debug', false);
+        Config::set('laravel-auth.webauthn.relying_party.potentially_trustworthy_origins', ['localhost']);
+        $user = $this->generateUser(['id' => 1, 'has_password' => false]);
+        $options = $this->mockPasskeyCreationOptionsTwo($user);
+        Session::put('auth.register.passkey_creation_options', serialize($options));
+
+        $response = $this->postJson(route('register'), [
+            'type' => 'passkey',
+            'credential' => [
+                'id' => 'ID_CFbjp7mfDuI4zwEe-49_g1-8',
+                'rawId' => 'ID_CFbjp7mfDuI4zwEe-49_g1-8',
+                'response' => [
+                    'clientDataJSON' => 'eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiSW1KOVVjS1dseFFlYjhWNE14U3JyZyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3QifQ',
+                    'attestationObject' => 'o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YViYSZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NdAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCA_whW46e5nw7iOM8BHvuPf4NfvpQECAyYgASFYIFZSx3fc0szMDz38Eu4ZBWjeAQMP0dWR_D-Dy3RA1tktIlggJzLmQt5ydTQ6PXRF4GFCgWyXJBT0giypbK0wducMmW4',
+                ],
+                'type' => 'public-key',
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['credential' => ['The credential field is invalid.']]);
+        $this->assertGuest();
+        $this->assertTrue(Session::has('auth.register.passkey_creation_options'));
+        $this->assertCount(0, MultiFactorCredential::all());
+        Event::assertNothingDispatched();
+    }
+
+    /** @test */
+    public function it_cannot_confirm_passkey_based_registration_on_an_insecure_origin_when_it_has_not_been_manually_marked_as_trustworthy(): void
+    {
+        Event::fake(Registered::class);
+        Config::set('app.debug', true);
+        Config::set('laravel-auth.webauthn.relying_party.potentially_trustworthy_origins', ['foo.com']);
+        $user = $this->generateUser(['id' => 1, 'has_password' => false]);
+        $options = $this->mockPasskeyCreationOptionsTwo($user);
+        Session::put('auth.register.passkey_creation_options', serialize($options));
+
+        $response = $this->postJson(route('register'), [
+            'type' => 'passkey',
+            'credential' => [
+                'id' => 'ID_CFbjp7mfDuI4zwEe-49_g1-8',
+                'rawId' => 'ID_CFbjp7mfDuI4zwEe-49_g1-8',
+                'response' => [
+                    'clientDataJSON' => 'eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiSW1KOVVjS1dseFFlYjhWNE14U3JyZyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3QifQ',
+                    'attestationObject' => 'o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YViYSZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NdAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCA_whW46e5nw7iOM8BHvuPf4NfvpQECAyYgASFYIFZSx3fc0szMDz38Eu4ZBWjeAQMP0dWR_D-Dy3RA1tktIlggJzLmQt5ydTQ6PXRF4GFCgWyXJBT0giypbK0wducMmW4',
+                ],
+                'type' => 'public-key',
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['credential' => ['The credential field is invalid.']]);
+        $this->assertGuest();
+        $this->assertTrue(Session::has('auth.register.passkey_creation_options'));
+        $this->assertCount(0, MultiFactorCredential::all());
+        Event::assertNothingDispatched();
+    }
+
+    /** @test */
     public function it_automatically_enables_sudo_mode_when_the_passkey_based_user_is_registered(): void
     {
         Carbon::setTestNow(now());


### PR DESCRIPTION
Currently it is not possible to run the webauthn flow from localhost (for local development purposes)
(This does not apply if you are using Valet with SSL-Certificates enabled)

What must be done for Webauthn support on localhost:
- SSL-Certificate or domain (localhost) is in secured_relying_parties
- Visit from http://localhost instead of http://127.0.0.1

This PR adds support for secured_relying_parties for the localhost option.

(This should probably never be active in production and only be added for local development purposes)