### PR TITLE
Don't run pint on pull requests

### DIFF
--- a/.github/workflows/fix-styling.yml
+++ b/.github/workflows/fix-styling.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - '*.x'
-  pull_request:
 
 jobs:
   pint:


### PR DESCRIPTION
in https://github.com/claudiodekker/laravel-auth/pull/45 you can see that Github Actions tries to commit the changes from pint to the PR-branch which doesn't exist in the base repository. (the branch only exists in the fork)

It seems like there are some problems with running the Github Commit Action in a Fork:
https://github.com/stefanzweifel/git-auto-commit-action#use-in-forks-from-public-repositories
(Though there are is a way to make it possible if the workflow doesn't run in the Fork but instead in the base repository)

I think it is fine to only run the commit action on the main branch. (There could be problems with the automatic changelog updater, if two workflows try to commit to the same branch)