### PR TITLE
Change monorepo splitter

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -6,7 +6,7 @@ on:
       - master
       - '*.x'
     tags:
-      - '*'
+      - 'v*'
 
 jobs:
   split:
@@ -20,28 +20,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-      - if: "!startsWith(github.ref, 'refs/tags/')"
-        uses: "danharrin/monorepo-split-github-action@v2.3.0"
+      - name: Split package ${{ matrix.package }}
+        uses: "claudiodekker/splitsh-action@v1.0.0"
         env:
           GITHUB_TOKEN: ${{ secrets.MONOREPO_SPLITTER_PERSONAL_ACCESS_TOKEN }}
         with:
-            package_directory: 'packages/${{ matrix.package }}'
-            repository_organization: 'claudiodekker'
-            repository_name: 'laravel-auth-${{ matrix.package }}'
-            branch: '${{ github.ref_name }}'
-            user_name: "Publisher"
-            user_email: "publisher@ubient.net"
-
-      - if: "startsWith(github.ref, 'refs/tags/')"
-        uses: "danharrin/monorepo-split-github-action@v2.3.0"
-        env:
-          GITHUB_TOKEN: ${{ secrets.MONOREPO_SPLITTER_PERSONAL_ACCESS_TOKEN }}
-        with:
-          tag: '${{ github.ref_name }}'
-          package_directory: 'packages/${{ matrix.package }}'
-          repository_organization: 'claudiodekker'
-          repository_name: 'laravel-auth-${{ matrix.package }}'
-          branch: 'master'
-          user_name: "Publisher"
-          user_email: "publisher@ubient.net"
+          prefix: "packages/${{ matrix.package }}"
+          remote: "https://github.com/claudiodekker/laravel-auth-${{ matrix.package }}.git"
+          reference: "${{ github.ref_name }}"
+          as_tag: "${{ startsWith(github.ref, 'refs/tags/') }}"


### PR DESCRIPTION
This PR swaps out the monorepo splitter, with the one that's used by both Symfony and Laravel. 

While this functions nearly identically, it attributes commits to users instead of re-publishing everything as a third-party username / as a single user.