### PR TITLE
Core: More predictable/consistent Trait methods

### DIFF
--- a/packages/bladebones/templates/Controllers/Challenges/MultiFactorChallengeController.bladetmpl
+++ b/packages/bladebones/templates/Controllers/Challenges/MultiFactorChallengeController.bladetmpl
@@ -70,7 +70,7 @@ class MultiFactorChallengeController extends BaseController
     /**
      * Sends a response that displays the multi-factor challenge page.
      */
-    protected function sendChallengePageResponse(Request $request, PublicKeyCredentialRequestOptions|null $options, Collection $availableCredentialTypes): View
+    protected function sendChallengePageResponse(Request $request, ?PublicKeyCredentialRequestOptions $options, Collection $availableCredentialTypes): View
     {
         return view('auth.challenges.multi_factor', [
             'availableMethods' => $availableCredentialTypes,

--- a/packages/bladebones/templates/Controllers/Challenges/SudoModeChallengeController.bladetmpl
+++ b/packages/bladebones/templates/Controllers/Challenges/SudoModeChallengeController.bladetmpl
@@ -68,7 +68,7 @@ class SudoModeChallengeController extends BaseController
     /**
      * Sends a response that displays the sudo-mode challenge page.
      */
-    protected function sendChallengePageResponse(Request $request, PublicKeyCredentialRequestOptions|null $options): View
+    protected function sendChallengePageResponse(Request $request, ?PublicKeyCredentialRequestOptions $options): View
     {
         return view('auth.challenges.sudo_mode', [
             'canUsePassword' => $this->supportsPasswordBasedConfirmation($request),

--- a/packages/core/src/Http/Concerns/HandlesLogouts.php
+++ b/packages/core/src/Http/Concerns/HandlesLogouts.php
@@ -8,6 +8,25 @@ use Illuminate\Support\Facades\Auth;
 trait HandlesLogouts
 {
     /**
+     * Sends a response indicating that the user has been signed out.
+     *
+     * @return mixed
+     */
+    abstract protected function sendLoggedOutResponse(Request $request);
+
+    /**
+     * Handle a logout request.
+     *
+     * @return mixed
+     */
+    protected function handleLogoutRequest(Request $request)
+    {
+        $this->logout($request);
+
+        return $this->sendLoggedOutResponse($request);
+    }
+
+    /**
      * Sign the user out of the application.
      */
     protected function logout(Request $request): void

--- a/packages/core/src/Http/Concerns/Login/PasskeyBasedAuthentication.php
+++ b/packages/core/src/Http/Concerns/Login/PasskeyBasedAuthentication.php
@@ -32,7 +32,7 @@ trait PasskeyBasedAuthentication
     /**
      * Initialize the passkey based authentication process by generating challenge details.
      */
-    protected function initializePasskeyAuthenticationOptions(Request $request): PublicKeyCredentialRequestOptions
+    protected function handlePasskeyBasedAuthenticationInitialization(Request $request): PublicKeyCredentialRequestOptions
     {
         return tap($this->generatePasskeyAuthenticationOptions($request), function ($options) use ($request) {
             $this->setPasskeyAuthenticationOptions($request, $options);
@@ -44,7 +44,7 @@ trait PasskeyBasedAuthentication
      *
      * @return mixed
      */
-    protected function handlePasskeyBasedAuthentication(Request $request)
+    protected function handlePasskeyBasedAuthenticationRequest(Request $request)
     {
         $this->validatePasskeyBasedRequest($request);
 

--- a/packages/core/src/Http/Concerns/Login/PasswordBasedAuthentication.php
+++ b/packages/core/src/Http/Concerns/Login/PasswordBasedAuthentication.php
@@ -30,7 +30,7 @@ trait PasswordBasedAuthentication
      *
      * @return mixed
      */
-    protected function handlePasswordBasedAuthentication(Request $request)
+    protected function handlePasswordBasedAuthenticationRequest(Request $request)
     {
         $this->validatePasswordBasedRequest($request);
 

--- a/packages/core/src/Http/Concerns/Registration/PasswordBasedRegistration.php
+++ b/packages/core/src/Http/Concerns/Registration/PasswordBasedRegistration.php
@@ -15,7 +15,7 @@ trait PasswordBasedRegistration
      *
      * @return mixed
      */
-    protected function handlePasswordBasedRegistration(Request $request)
+    protected function handlePasswordBasedRegistrationRequest(Request $request)
     {
         $this->validatePasswordBasedRequest($request);
 

--- a/packages/core/src/Http/Controllers/AccountRecoveryRequestController.php
+++ b/packages/core/src/Http/Controllers/AccountRecoveryRequestController.php
@@ -110,7 +110,7 @@ abstract class AccountRecoveryRequestController
     /**
      * Resolve the User that should be recovered.
      */
-    protected function getUser(Request $request): CanResetPassword|null
+    protected function getUser(Request $request): ?CanResetPassword
     {
         /** @var \Illuminate\Database\Eloquent\Builder $query */
         $query = LaravelAuth::userModel()::query();

--- a/packages/core/src/Http/Controllers/Challenges/MultiFactorChallengeController.php
+++ b/packages/core/src/Http/Controllers/Challenges/MultiFactorChallengeController.php
@@ -86,7 +86,7 @@ abstract class MultiFactorChallengeController
 
         $availableTypes = $this->filterAvailableCredentialTypes($credentials);
         $publicKeyCredentials = $this->filterPublicKeyCredentials($credentials);
-        $options = $this->initializePublicKeyChallenge($request, $publicKeyCredentials);
+        $options = $this->handlePublicKeyChallengeInitialization($request, $publicKeyCredentials);
 
         return $this->sendChallengePageResponse($request, $options, $availableTypes);
     }

--- a/packages/core/src/Http/Controllers/Challenges/MultiFactorChallengeController.php
+++ b/packages/core/src/Http/Controllers/Challenges/MultiFactorChallengeController.php
@@ -34,7 +34,7 @@ abstract class MultiFactorChallengeController
      *
      * @return mixed
      */
-    abstract protected function sendChallengePageResponse(Request $request, PublicKeyCredentialRequestOptions|null $options, Collection $availableCredentialTypes);
+    abstract protected function sendChallengePageResponse(Request $request, ?PublicKeyCredentialRequestOptions $options, Collection $availableCredentialTypes);
 
     /**
      * Sends a response indicating that the multi-factor challenge has succeeded.

--- a/packages/core/src/Http/Controllers/Challenges/SudoModeChallengeController.php
+++ b/packages/core/src/Http/Controllers/Challenges/SudoModeChallengeController.php
@@ -59,7 +59,7 @@ abstract class SudoModeChallengeController
             return $this->sendConfirmationNotRequiredResponse($request);
         }
 
-        return $this->sendChallengePageResponse($request, $this->initializePublicKeyChallenge($request));
+        return $this->sendChallengePageResponse($request, $this->handlePublicKeyChallengeInitialization($request));
     }
 
     /**
@@ -126,7 +126,7 @@ abstract class SudoModeChallengeController
      */
     protected function sendPasswordChallengeSuccessfulResponse(Request $request)
     {
-        $this->clearPublicKeyChallengeOptions($request);
+        $this->handlePublicKeyChallengeInvalidation($request);
 
         $this->enableSudoMode($request);
         $this->emitSudoModeEnabledEvent($request);

--- a/packages/core/src/Http/Controllers/Challenges/SudoModeChallengeController.php
+++ b/packages/core/src/Http/Controllers/Challenges/SudoModeChallengeController.php
@@ -29,7 +29,7 @@ abstract class SudoModeChallengeController
      *
      * @return mixed
      */
-    abstract protected function sendChallengePageResponse(Request $request, PublicKeyCredentialRequestOptions|null $options);
+    abstract protected function sendChallengePageResponse(Request $request, ?PublicKeyCredentialRequestOptions $options);
 
     /**
      * Sends a response indicating that sudo-mode has been enabled.

--- a/packages/core/src/Http/Controllers/LoginController.php
+++ b/packages/core/src/Http/Controllers/LoginController.php
@@ -3,7 +3,6 @@
 namespace ClaudioDekker\LaravelAuth\Http\Controllers;
 
 use App\Providers\RouteServiceProvider;
-use ClaudioDekker\LaravelAuth\Events\Authenticated;
 use ClaudioDekker\LaravelAuth\Events\AuthenticationFailed;
 use ClaudioDekker\LaravelAuth\Events\Mixins\EmitsAuthenticatedEvent;
 use ClaudioDekker\LaravelAuth\Http\Concerns\EnablesSudoMode;
@@ -50,13 +49,6 @@ abstract class LoginController
     abstract protected function sendAuthenticationFailedResponse(Request $request);
 
     /**
-     * Sends a response indicating that the user has been signed out.
-     *
-     * @return mixed
-     */
-    abstract protected function sendLoggedOutResponse(Request $request);
-
-    /**
      * Handle an incoming request to view the login page.
      *
      * @see static::sendLoginPageResponse()
@@ -65,7 +57,7 @@ abstract class LoginController
      */
     public function create(Request $request)
     {
-        $options = $this->initializePasskeyAuthenticationOptions($request);
+        $options = $this->handlePasskeyBasedAuthenticationInitialization($request);
 
         return $this->sendLoginPageResponse($request, $options);
     }
@@ -84,10 +76,10 @@ abstract class LoginController
     public function store(Request $request)
     {
         if ($this->isPasswordBasedAuthenticationAttempt($request)) {
-            return $this->handlePasswordBasedAuthentication($request);
+            return $this->handlePasswordBasedAuthenticationRequest($request);
         }
 
-        return $this->handlePasskeyBasedAuthentication($request);
+        return $this->handlePasskeyBasedAuthenticationRequest($request);
     }
 
     /**
@@ -99,9 +91,7 @@ abstract class LoginController
      */
     public function destroy(Request $request)
     {
-        $this->logout($request);
-
-        return $this->sendLoggedOutResponse($request);
+        return $this->handleLogoutRequest($request);
     }
 
     /**

--- a/packages/core/src/Http/Controllers/RegisterController.php
+++ b/packages/core/src/Http/Controllers/RegisterController.php
@@ -50,10 +50,10 @@ abstract class RegisterController
     public function store(Request $request)
     {
         if ($this->isPasswordBasedRegistrationAttempt($request)) {
-            return $this->handlePasswordBasedRegistration($request);
+            return $this->handlePasswordBasedRegistrationRequest($request);
         }
 
-        return $this->handlePasskeyBasedRegistration($request);
+        return $this->handlePasskeyBasedRegistrationRequest($request);
     }
 
     /**
@@ -66,7 +66,7 @@ abstract class RegisterController
      */
     public function destroy(Request $request)
     {
-        return $this->cancelPasskeyRegistration($request);
+        return $this->handlePasskeyBasedRegistrationCancellationRequest($request);
     }
 
     /**

--- a/packages/core/src/Methods/WebAuthn/Contracts/WebAuthnContract.php
+++ b/packages/core/src/Methods/WebAuthn/Contracts/WebAuthnContract.php
@@ -17,7 +17,7 @@ interface WebAuthnContract
      * @link https://www.w3.org/TR/webauthn-2/#server-side-public-key-credential-source
      * @link https://www.w3.org/TR/webauthn-2/#dictdef-publickeycredentialcreationoptions
      */
-    public function generatePublicKeyCreationOptions(PublicKeyCredentialUserEntity $user, ?Collection $excludeCredentials = null): PublicKeyCredentialCreationOptions;
+    public function generatePublicKeyCreationOptions(PublicKeyCredentialUserEntity $user, Collection $excludeCredentials = null): PublicKeyCredentialCreationOptions;
 
     /**
      * Prepares the challenge options used to create a new passkey credential.
@@ -40,7 +40,7 @@ interface WebAuthnContract
      *
      * @link https://www.w3.org/TR/webauthn-2/#dictdef-publickeycredentialrequestoptions
      */
-    public function generatePublicKeyRequestOptions(?Collection $allowCredentials = null): PublicKeyCredentialRequestOptions;
+    public function generatePublicKeyRequestOptions(Collection $allowCredentials = null): PublicKeyCredentialRequestOptions;
 
     /**
      * Prepares the challenge options used to authenticate a passkey credential.
@@ -55,5 +55,5 @@ interface WebAuthnContract
      * @throws \ClaudioDekker\LaravelAuth\Methods\WebAuthn\Exceptions\InvalidPublicKeyCredentialException
      * @throws \ClaudioDekker\LaravelAuth\Methods\WebAuthn\Exceptions\UnexpectedActionException
      */
-    public function validateCredential(ServerRequestInterface $request, PublicKeyCredentialRequestOptions $publicKeyCredentialRequestOptions, ?PublicKeyCredentialUserEntity $user = null): CredentialAttributes;
+    public function validateCredential(ServerRequestInterface $request, PublicKeyCredentialRequestOptions $publicKeyCredentialRequestOptions, PublicKeyCredentialUserEntity $user = null): CredentialAttributes;
 }

--- a/packages/core/src/Methods/WebAuthn/SpomkyWebAuthn.php
+++ b/packages/core/src/Methods/WebAuthn/SpomkyWebAuthn.php
@@ -63,7 +63,7 @@ class SpomkyWebAuthn implements WebAuthnContract
      * @link https://www.w3.org/TR/webauthn-2/#server-side-public-key-credential-source
      * @link https://www.w3.org/TR/webauthn-2/#dictdef-publickeycredentialcreationoptions
      */
-    public function generatePublicKeyCreationOptions(PublicKeyCredentialUserEntity $user, ?Collection $excludeCredentials = null): PublicKeyCredentialCreationOptionsContract
+    public function generatePublicKeyCreationOptions(PublicKeyCredentialUserEntity $user, Collection $excludeCredentials = null): PublicKeyCredentialCreationOptionsContract
     {
         $options = \Webauthn\PublicKeyCredentialCreationOptions::create(
             $this->relyingPartyEntity(),
@@ -151,7 +151,7 @@ class SpomkyWebAuthn implements WebAuthnContract
      *
      * @link https://www.w3.org/TR/webauthn-2/#dictdef-publickeycredentialrequestoptions
      */
-    public function generatePublicKeyRequestOptions(?Collection $allowCredentials = null): PublicKeyCredentialRequestOptionsContract
+    public function generatePublicKeyRequestOptions(Collection $allowCredentials = null): PublicKeyCredentialRequestOptionsContract
     {
         $options = \Webauthn\PublicKeyCredentialRequestOptions::create(
             $this->generateChallenge(),
@@ -186,7 +186,7 @@ class SpomkyWebAuthn implements WebAuthnContract
      * @throws \ClaudioDekker\LaravelAuth\Methods\WebAuthn\Exceptions\InvalidPublicKeyCredentialException
      * @throws \ClaudioDekker\LaravelAuth\Methods\WebAuthn\Exceptions\UnexpectedActionException
      */
-    public function validateCredential(ServerRequestInterface $request, PublicKeyCredentialRequestOptionsContract $publicKeyCredentialRequestOptions, ?PublicKeyCredentialUserEntity $user = null): CredentialAttributes
+    public function validateCredential(ServerRequestInterface $request, PublicKeyCredentialRequestOptionsContract $publicKeyCredentialRequestOptions, PublicKeyCredentialUserEntity $user = null): CredentialAttributes
     {
         $parsedBody = $request->getParsedBody();
         if (! is_array($parsedBody) || ! array_key_exists('credential', $parsedBody) || ! is_array($parsedBody['credential'])) {


### PR DESCRIPTION
This PR adds a couple of tweaks to the Traits:
- It moves some of the logout-related methods to the `HandlesLogouts` trait
- It moves `handleXyzRequest` methods to the top of the trait, for better visibility.
- It aligns methods that the user is supposed to use in their code when using a trait to `handleXyzRequest`. This does not mean that the other methods aren't supposed to be used/overridden by the user, it just makes it clearer to spot which are the "main" entrypoint methods of a trait. 