### PR TITLE
Add Timebox (prevent timeless timing attack vulnerability)

### DIFF
--- a/packages/bladebones/templates/Tests/AuthenticationTest.bladetmpl
+++ b/packages/bladebones/templates/Tests/AuthenticationTest.bladetmpl
@@ -69,4 +69,11 @@ class AuthenticationTest extends TestCase
     use RegisterPublicKeyCredentialTests;
     use RegisterTotpCredentialTests;
     use RemoveCredentialTests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->useInstantlyResolvingTimebox();
+    }
 }

--- a/packages/bladebones/tests/Feature/Console/GenerateCommandTest.php
+++ b/packages/bladebones/tests/Feature/Console/GenerateCommandTest.php
@@ -123,6 +123,13 @@ class AuthenticationTest extends TestCase
     use RegisterPublicKeyCredentialTests;
     use RegisterTotpCredentialTests;
     use RemoveCredentialTests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \$this->useInstantlyResolvingTimebox();
+    }
 }
 
 EOF;
@@ -221,6 +228,13 @@ class AuthenticationTest extends TestCase
     use RegisterPublicKeyCredentialTests;
     use RegisterTotpCredentialTests;
     use RemoveCredentialTests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \$this->useInstantlyResolvingTimebox();
+    }
 }
 
 EOF;
@@ -309,6 +323,13 @@ class AuthenticationTest extends TestCase
     use RegisterPublicKeyCredentialTests;
     use RegisterTotpCredentialTests;
     use RemoveCredentialTests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \$this->useInstantlyResolvingTimebox();
+    }
 }
 
 EOF;
@@ -398,6 +419,13 @@ class AuthenticationTest extends TestCase
     use RegisterPublicKeyCredentialTests;
     use RegisterTotpCredentialTests;
     use RemoveCredentialTests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \$this->useInstantlyResolvingTimebox();
+    }
 }
 
 EOF;
@@ -484,6 +512,13 @@ class AuthenticationTest extends TestCase
     use RegisterPublicKeyCredentialTests;
     use RegisterTotpCredentialTests;
     use RemoveCredentialTests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \$this->useInstantlyResolvingTimebox();
+    }
 }
 
 EOF;
@@ -572,6 +607,13 @@ class AuthenticationTest extends TestCase
     use RegisterPublicKeyCredentialTests;
     use RegisterTotpCredentialTests;
     use RemoveCredentialTests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \$this->useInstantlyResolvingTimebox();
+    }
 }
 
 EOF;
@@ -661,6 +703,13 @@ class AuthenticationTest extends TestCase
     use RegisterPublicKeyCredentialTests;
     use RegisterTotpCredentialTests;
     use RemoveCredentialTests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \$this->useInstantlyResolvingTimebox();
+    }
 }
 
 EOF;
@@ -747,6 +796,13 @@ class AuthenticationTest extends TestCase
     use RegisterPublicKeyCredentialTests;
     use RegisterTotpCredentialTests;
     use RemoveCredentialTests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \$this->useInstantlyResolvingTimebox();
+    }
 }
 
 EOF;
@@ -850,6 +906,13 @@ class AuthenticationTest extends TestCase
     use RegisterPublicKeyCredentialTests;
     use RegisterTotpCredentialTests;
     use RemoveCredentialTests;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \$this->useInstantlyResolvingTimebox();
+    }
 }
 
 EOF;

--- a/packages/core/src/Http/Concerns/Login/PasskeyBasedAuthentication.php
+++ b/packages/core/src/Http/Concerns/Login/PasskeyBasedAuthentication.php
@@ -47,14 +47,14 @@ trait PasskeyBasedAuthentication
      */
     protected function handlePasskeyBasedAuthenticationRequest(Request $request)
     {
+        if ($this->isCurrentlyRateLimited($request)) {
+            $this->emitLockoutEvent($request);
+
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
+        }
+
         return App::make(Timebox::class)->call(function (Timebox $timebox) use ($request) {
             $this->validatePasskeyBasedRequest($request);
-
-            if ($this->isCurrentlyRateLimited($request)) {
-                $this->emitLockoutEvent($request);
-
-                return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
-            }
 
             if (! $options = $this->getPasskeyAuthenticationOptions($request)) {
                 return $this->sendInvalidPasskeyAuthenticationStateResponse($request);

--- a/packages/core/src/Http/Concerns/Login/PasswordBasedAuthentication.php
+++ b/packages/core/src/Http/Concerns/Login/PasswordBasedAuthentication.php
@@ -34,14 +34,14 @@ trait PasswordBasedAuthentication
      */
     protected function handlePasswordBasedAuthenticationRequest(Request $request)
     {
+        if ($this->isCurrentlyRateLimited($request)) {
+            $this->emitLockoutEvent($request);
+
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
+        }
+
         return App::make(Timebox::class)->call(function (Timebox $timebox) use ($request) {
             $this->validatePasswordBasedRequest($request);
-
-            if ($this->isCurrentlyRateLimited($request)) {
-                $this->emitLockoutEvent($request);
-
-                return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
-            }
 
             if (! $user = $this->validatePasswordBasedCredentials($request)) {
                 $this->incrementRateLimitingCounter($request);

--- a/packages/core/src/Http/Concerns/Login/PasswordBasedAuthentication.php
+++ b/packages/core/src/Http/Concerns/Login/PasswordBasedAuthentication.php
@@ -10,8 +10,10 @@ use ClaudioDekker\LaravelAuth\LaravelAuth;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Timebox;
 
 trait PasswordBasedAuthentication
 {
@@ -32,38 +34,41 @@ trait PasswordBasedAuthentication
      */
     protected function handlePasswordBasedAuthenticationRequest(Request $request)
     {
-        $this->validatePasswordBasedRequest($request);
+        return App::make(Timebox::class)->call(function (Timebox $timebox) use ($request) {
+            $this->validatePasswordBasedRequest($request);
 
-        if ($this->isCurrentlyRateLimited($request)) {
-            $this->emitLockoutEvent($request);
+            if ($this->isCurrentlyRateLimited($request)) {
+                $this->emitLockoutEvent($request);
 
-            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
-        }
+                return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
+            }
 
-        if (! $user = $this->validatePasswordBasedCredentials($request)) {
-            $this->incrementRateLimitingCounter($request);
-            $this->emitAuthenticationFailedEvent($request);
+            if (! $user = $this->validatePasswordBasedCredentials($request)) {
+                $this->incrementRateLimitingCounter($request);
+                $this->emitAuthenticationFailedEvent($request);
 
-            return $this->sendAuthenticationFailedResponse($request);
-        }
+                return $this->sendAuthenticationFailedResponse($request);
+            }
 
-        $this->sanitizeMultiFactorSessionState($request);
+            $this->sanitizeMultiFactorSessionState($request);
+            $timebox->returnEarly();
 
-        $credentials = $this->fetchMultiFactorCredentials($user);
-        if ($credentials->isEmpty()) {
-            $this->resetRateLimitingCounter($request);
-            $this->authenticate($user, $this->isRememberingUser($request));
-            $this->enableSudoMode($request);
-            $this->emitAuthenticatedEvent($request, $user);
+            $credentials = $this->fetchMultiFactorCredentials($user);
+            if ($credentials->isEmpty()) {
+                $this->resetRateLimitingCounter($request);
+                $this->authenticate($user, $this->isRememberingUser($request));
+                $this->enableSudoMode($request);
+                $this->emitAuthenticatedEvent($request, $user);
 
-            return $this->sendAuthenticatedResponse($request, $user);
-        }
+                return $this->sendAuthenticatedResponse($request, $user);
+            }
 
-        $preferredMethod = $this->determinePreferredMultiFactorMethod($user, $credentials);
-        $this->prepareMultiFactorAuthenticationDetails($request, $user);
-        $this->emitMultiFactorChallengedEvent($request, $user);
+            $preferredMethod = $this->determinePreferredMultiFactorMethod($user, $credentials);
+            $this->prepareMultiFactorAuthenticationDetails($request, $user);
+            $this->emitMultiFactorChallengedEvent($request, $user);
 
-        return $this->sendMultiFactorChallengeResponse($request, $preferredMethod);
+            return $this->sendMultiFactorChallengeResponse($request, $preferredMethod);
+        }, 300 * 1000);
     }
 
     /**

--- a/packages/core/src/Http/Controllers/Challenges/AccountRecoveryChallengeController.php
+++ b/packages/core/src/Http/Controllers/Challenges/AccountRecoveryChallengeController.php
@@ -98,13 +98,13 @@ abstract class AccountRecoveryChallengeController
      */
     public function store(Request $request, string $token)
     {
+        if ($this->isCurrentlyRateLimited($request)) {
+            $this->emitLockoutEvent($request);
+
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
+        }
+
         return App::make(Timebox::class)->call(function (Timebox $timebox) use ($request, $token) {
-            if ($this->isCurrentlyRateLimited($request)) {
-                $this->emitLockoutEvent($request);
-
-                return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
-            }
-
             if (! $user = $this->resolveUser($request)) {
                 $this->incrementRateLimitingCounter($request);
 

--- a/packages/core/src/Http/Controllers/Challenges/AccountRecoveryChallengeController.php
+++ b/packages/core/src/Http/Controllers/Challenges/AccountRecoveryChallengeController.php
@@ -11,9 +11,11 @@ use ClaudioDekker\LaravelAuth\LaravelAuth;
 use ClaudioDekker\LaravelAuth\RecoveryCodeManager;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Timebox;
 
 abstract class AccountRecoveryChallengeController
 {
@@ -63,21 +65,25 @@ abstract class AccountRecoveryChallengeController
      */
     public function create(Request $request, string $token)
     {
-        if (! $user = $this->resolveUser($request)) {
-            return $this->sendInvalidRecoveryLinkResponse($request);
-        }
+        return App::make(Timebox::class)->call(function (Timebox $timebox) use ($request, $token) {
+            if (! $user = $this->resolveUser($request)) {
+                return $this->sendInvalidRecoveryLinkResponse($request);
+            }
 
-        if (! $this->isValidRecoveryLink($user, $token)) {
-            return $this->sendInvalidRecoveryLinkResponse($request);
-        }
+            if (! $this->isValidRecoveryLink($user, $token)) {
+                return $this->sendInvalidRecoveryLinkResponse($request);
+            }
 
-        if (! $this->hasRecoveryCodes($request, $user)) {
-            $this->invalidateRecoveryLink($request, $user);
+            $timebox->returnEarly();
 
-            return $this->handleAccountRecoveredResponse($request, $user);
-        }
+            if (! $this->hasRecoveryCodes($request, $user)) {
+                $this->invalidateRecoveryLink($request, $user);
 
-        return $this->sendChallengePageResponse($request, $token);
+                return $this->handleAccountRecoveredResponse($request, $user);
+            }
+
+            return $this->sendChallengePageResponse($request, $token);
+        }, 300 * 1000);
     }
 
     /**
@@ -92,42 +98,46 @@ abstract class AccountRecoveryChallengeController
      */
     public function store(Request $request, string $token)
     {
-        if ($this->isCurrentlyRateLimited($request)) {
-            $this->emitLockoutEvent($request);
+        return App::make(Timebox::class)->call(function (Timebox $timebox) use ($request, $token) {
+            if ($this->isCurrentlyRateLimited($request)) {
+                $this->emitLockoutEvent($request);
 
-            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
-        }
+                return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
+            }
 
-        if (! $user = $this->resolveUser($request)) {
-            $this->incrementRateLimitingCounter($request);
+            if (! $user = $this->resolveUser($request)) {
+                $this->incrementRateLimitingCounter($request);
 
-            return $this->sendInvalidRecoveryLinkResponse($request);
-        }
+                return $this->sendInvalidRecoveryLinkResponse($request);
+            }
 
-        if (! $this->isValidRecoveryLink($user, $token)) {
-            $this->incrementRateLimitingCounter($request);
+            if (! $this->isValidRecoveryLink($user, $token)) {
+                $this->incrementRateLimitingCounter($request);
 
-            return $this->sendInvalidRecoveryLinkResponse($request);
-        }
+                return $this->sendInvalidRecoveryLinkResponse($request);
+            }
 
-        if (! $this->hasRecoveryCodes($request, $user)) {
+            if (! $this->hasRecoveryCodes($request, $user)) {
+                $this->invalidateRecoveryLink($request, $user);
+                $timebox->returnEarly();
+
+                return $this->handleAccountRecoveredResponse($request, $user);
+            }
+
+            if (! $this->hasValidRecoveryCode($request, $user)) {
+                $this->incrementRateLimitingCounter($request);
+                $this->emitAccountRecoveryFailedEvent($request, $user);
+
+                return $this->sendInvalidRecoveryCodeResponse($request);
+            }
+
+            $this->resetRateLimitingCounter($request);
+            $this->invalidateRecoveryCode($request, $user);
             $this->invalidateRecoveryLink($request, $user);
+            $timebox->returnEarly();
 
             return $this->handleAccountRecoveredResponse($request, $user);
-        }
-
-        if (! $this->hasValidRecoveryCode($request, $user)) {
-            $this->incrementRateLimitingCounter($request);
-            $this->emitAccountRecoveryFailedEvent($request, $user);
-
-            return $this->sendInvalidRecoveryCodeResponse($request);
-        }
-
-        $this->resetRateLimitingCounter($request);
-        $this->invalidateRecoveryCode($request, $user);
-        $this->invalidateRecoveryLink($request, $user);
-
-        return $this->handleAccountRecoveredResponse($request, $user);
+        }, 300 * 1000);
     }
 
     /**

--- a/packages/core/src/Http/Controllers/Challenges/SudoModeChallengeController.php
+++ b/packages/core/src/Http/Controllers/Challenges/SudoModeChallengeController.php
@@ -13,8 +13,10 @@ use ClaudioDekker\LaravelAuth\Http\Modifiers\EmailBased;
 use ClaudioDekker\LaravelAuth\Specifications\WebAuthn\Dictionaries\PublicKeyCredentialRequestOptions;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Timebox;
 
 abstract class SudoModeChallengeController
 {
@@ -59,7 +61,9 @@ abstract class SudoModeChallengeController
             return $this->sendConfirmationNotRequiredResponse($request);
         }
 
-        return $this->sendChallengePageResponse($request, $this->handlePublicKeyChallengeInitialization($request));
+        return App::make(Timebox::class)->call(function () use ($request) {
+            return $this->sendChallengePageResponse($request, $this->handlePublicKeyChallengeInitialization($request));
+        }, 300 * 1000);
     }
 
     /**

--- a/packages/core/src/Http/Mixins/Challenges/PasswordChallenge.php
+++ b/packages/core/src/Http/Mixins/Challenges/PasswordChallenge.php
@@ -33,14 +33,14 @@ trait PasswordChallenge
      */
     protected function handlePasswordChallengeRequest(Request $request)
     {
+        if ($this->isCurrentlyRateLimited($request)) {
+            $this->emitLockoutEvent($request);
+
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
+        }
+
         return App::make(Timebox::class)->call(function (Timebox $timebox) use ($request) {
             $this->validatePasswordChallengeRequest($request);
-
-            if ($this->isCurrentlyRateLimited($request)) {
-                $this->emitLockoutEvent($request);
-
-                return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
-            }
 
             if (! $this->hasValidPassword($request)) {
                 $this->incrementRateLimitingCounter($request);

--- a/packages/core/src/Http/Mixins/Challenges/PublicKeyChallenge.php
+++ b/packages/core/src/Http/Mixins/Challenges/PublicKeyChallenge.php
@@ -84,14 +84,14 @@ trait PublicKeyChallenge
      */
     protected function handlePublicKeyChallengeRequest(Request $request)
     {
+        if ($this->isCurrentlyRateLimited($request)) {
+            $this->emitLockoutEvent($request);
+
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
+        }
+
         return App::make(Timebox::class)->call(function (Timebox $timebox) use ($request) {
             $this->validatePublicKeyChallengeRequest($request);
-
-            if ($this->isCurrentlyRateLimited($request)) {
-                $this->emitLockoutEvent($request);
-
-                return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
-            }
 
             if (! $options = $this->getPublicKeyChallengeOptions($request)) {
                 return $this->sendInvalidPublicKeyChallengeStateResponse($request);

--- a/packages/core/src/Http/Mixins/Challenges/TotpChallenge.php
+++ b/packages/core/src/Http/Mixins/Challenges/TotpChallenge.php
@@ -37,14 +37,14 @@ trait TotpChallenge
      */
     protected function handleTotpChallengeRequest(Request $request)
     {
+        if ($this->isCurrentlyRateLimited($request)) {
+            $this->emitLockoutEvent($request);
+
+            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
+        }
+
         return App::make(Timebox::class)->call(function (Timebox $timebox) use ($request) {
             $this->validateTotpChallengeRequest($request);
-
-            if ($this->isCurrentlyRateLimited($request)) {
-                $this->emitLockoutEvent($request);
-
-                return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
-            }
 
             if (! $this->hasValidTotpCode($request)) {
                 $this->incrementRateLimitingCounter($request);

--- a/packages/core/src/Http/Mixins/Challenges/TotpChallenge.php
+++ b/packages/core/src/Http/Mixins/Challenges/TotpChallenge.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Timebox;
 
 trait TotpChallenge
 {
@@ -36,23 +37,26 @@ trait TotpChallenge
      */
     protected function handleTotpChallengeRequest(Request $request)
     {
-        $this->validateTotpChallengeRequest($request);
+        return App::make(Timebox::class)->call(function (Timebox $timebox) use ($request) {
+            $this->validateTotpChallengeRequest($request);
 
-        if ($this->isCurrentlyRateLimited($request)) {
-            $this->emitLockoutEvent($request);
+            if ($this->isCurrentlyRateLimited($request)) {
+                $this->emitLockoutEvent($request);
 
-            return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
-        }
+                return $this->sendRateLimitedResponse($request, $this->rateLimitExpiresInSeconds($request));
+            }
 
-        if (! $this->hasValidTotpCode($request)) {
-            $this->incrementRateLimitingCounter($request);
+            if (! $this->hasValidTotpCode($request)) {
+                $this->incrementRateLimitingCounter($request);
 
-            return $this->sendTotpChallengeFailedResponse($request);
-        }
+                return $this->sendTotpChallengeFailedResponse($request);
+            }
 
-        $this->resetRateLimitingCounter($request);
+            $this->resetRateLimitingCounter($request);
+            $timebox->returnEarly();
 
-        return $this->sendTotpChallengeSuccessfulResponse($request);
+            return $this->sendTotpChallengeSuccessfulResponse($request);
+        }, 300 * 1000);
     }
 
     /**

--- a/packages/core/src/Testing/EmailVerification/RegisterWithVerificationEmailTests.php
+++ b/packages/core/src/Testing/EmailVerification/RegisterWithVerificationEmailTests.php
@@ -14,6 +14,7 @@ trait RegisterWithVerificationEmailTests
     {
         Notification::fake();
         $this->assertCount(0, LaravelAuth::userModel()::all());
+        $this->expectTimeboxWithEarlyReturn();
 
         $this->submitPasswordBasedRegisterAttempt();
 
@@ -27,6 +28,7 @@ trait RegisterWithVerificationEmailTests
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         $options = $this->mockPasskeyCreationOptions($user);
         Session::put('auth.register.passkey_creation_options', serialize($options));
+        $this->expectTimeboxWithEarlyReturn();
 
         $this->submitPasskeyBasedRegisterAttempt();
 

--- a/packages/core/src/Testing/EmailVerification/RegisterWithoutVerificationEmailTests.php
+++ b/packages/core/src/Testing/EmailVerification/RegisterWithoutVerificationEmailTests.php
@@ -13,6 +13,7 @@ trait RegisterWithoutVerificationEmailTests
     {
         Notification::fake();
         $this->assertCount(0, LaravelAuth::userModel()::all());
+        $this->expectTimeboxWithEarlyReturn();
 
         $this->submitPasswordBasedRegisterAttempt();
 
@@ -27,6 +28,7 @@ trait RegisterWithoutVerificationEmailTests
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         $options = $this->mockPasskeyCreationOptions($user);
         Session::put('auth.register.passkey_creation_options', serialize($options));
+        $this->expectTimeboxWithEarlyReturn();
 
         $this->submitPasskeyBasedRegisterAttempt();
 

--- a/packages/core/src/Testing/Helpers.php
+++ b/packages/core/src/Testing/Helpers.php
@@ -265,7 +265,7 @@ trait Helpers
         });
     }
 
-    protected function expectSuccessfulTimebox(): void
+    protected function expectTimeboxWithEarlyReturn(): void
     {
         $this->partialMock(Timebox::class, function (MockInterface $timebox) {
             $timebox->shouldReceive('call')->once()->andReturnUsing(function ($callback) use ($timebox) {

--- a/packages/core/src/Testing/Helpers.php
+++ b/packages/core/src/Testing/Helpers.php
@@ -10,6 +10,7 @@ use ClaudioDekker\LaravelAuth\Methods\WebAuthn\SpomkyWebAuthn;
 use ClaudioDekker\LaravelAuth\Specifications\WebAuthn\Dictionaries\PublicKeyCredentialCreationOptions;
 use ClaudioDekker\LaravelAuth\Specifications\WebAuthn\Dictionaries\PublicKeyCredentialRequestOptions;
 use ClaudioDekker\LaravelAuth\Specifications\WebAuthn\Dictionaries\PublicKeyCredentialUserEntity;
+use ClaudioDekker\LaravelAuth\Testing\Support\InstantlyResolvingTimebox;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -19,6 +20,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
+use Illuminate\Support\Timebox;
 use Illuminate\Testing\TestResponse;
 use Mockery\MockInterface;
 
@@ -247,5 +249,28 @@ trait Helpers
             ],
             'type' => 'public-key',
         ];
+    }
+
+    protected function useInstantlyResolvingTimebox()
+    {
+        App::bind(Timebox::class, fn () => new InstantlyResolvingTimebox());
+    }
+
+    protected function expectTimebox(): void
+    {
+        $this->partialMock(Timebox::class, function (MockInterface $timebox) {
+            $timebox->shouldReceive('call')->once()->andReturnUsing(function ($callback) use ($timebox) {
+                return $callback($timebox->shouldReceive('returnEarly')->never()->getMock());
+            });
+        });
+    }
+
+    protected function expectSuccessfulTimebox(): void
+    {
+        $this->partialMock(Timebox::class, function (MockInterface $timebox) {
+            $timebox->shouldReceive('call')->once()->andReturnUsing(function ($callback) use ($timebox) {
+                return $callback($timebox->shouldReceive('returnEarly')->once()->getMock());
+            });
+        });
     }
 }

--- a/packages/core/src/Testing/Partials/CancelPasskeyBasedRegistrationTests.php
+++ b/packages/core/src/Testing/Partials/CancelPasskeyBasedRegistrationTests.php
@@ -24,6 +24,7 @@ trait CancelPasskeyBasedRegistrationTests
             $this->assertTrue(password_verify('AUTOMATICALLY-GENERATED-PASSWORD-HASH', $user->password));
             $this->assertFalse($user->has_password);
         });
+        $this->expectTimebox();
 
         $response = $this->deleteJson(route('register'));
 
@@ -56,6 +57,7 @@ trait CancelPasskeyBasedRegistrationTests
     {
         Event::fake([Registered::class]);
         $this->assertFalse(Session::has('auth.register.passkey_creation_options'));
+        $this->expectTimebox();
 
         $response = $this->deleteJson(route('register'));
 

--- a/packages/core/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingPublicKeyCredentialTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingPublicKeyCredentialTests.php
@@ -27,6 +27,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -62,6 +63,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
             'secret' => '{"id":"eHouz/Zi7+BmByHjJ/tx9h4a1WZsK4IzUmgGjkhyOodPGAyUqUp/B9yUkflXY3yHWsNtsrgCXQ3HjAIFUeZB+w==","publicKey":"pQECAyYgASFYIJV56vRrFusoDf9hm3iDmllcxxXzzKyO9WruKw4kWx7zIlgg/nq63l8IMJcIdKDJcXRh9hoz0L+nVwP1Oxil3/oNQYs=","signCount":117,"userHandle":"1","transports":[]}',
         ]);
         $this->preAuthenticate($user);
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -96,6 +98,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -131,6 +134,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -166,6 +170,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -201,6 +206,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         ]);
         $this->preAuthenticate($user, ['remember' => 'on']);
         $this->mockPublicKeyRequestOptions([$credential]);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -237,6 +243,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -275,6 +282,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -312,6 +320,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         $this->preAuthenticate($user);
         $this->assertNotEmpty($previousId = session()->getId());
         $this->mockPublicKeyRequestOptions([$credential]);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -352,11 +361,13 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         // This step emulates the attacker signing in to their account, but not completing the public-key credential challenge.
         // This places the public key challenge request object in the session, which includes all the allowed credentials.
         // (While we're not actually using the endpoints directly, the effect is identical when crafting requests)
+        $this->expectSuccessfulTimebox();
         $this->preAuthenticate($userA, [$this->usernameField() => $userA->{$this->usernameField()}]);
         $this->mockPublicKeyRequestOptions([$credentialA]);
 
         // Next, instead of completing the challenge, the attacker will take their session id / CSRF tokens etc., and crafts
         // a manual 'login' attempt to that signs in the victim, which returns a redirect to the victim's MFA challenge.
+        $this->expectSuccessfulTimebox();
         $craftedLogin = $this->preAuthenticate($userB, [$this->usernameField() => $userB->{$this->usernameField()}]);
         $craftedLogin->assertExactJson(['redirect_url' => route('login.challenge.multi_factor')]);
 

--- a/packages/core/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingPublicKeyCredentialTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingPublicKeyCredentialTests.php
@@ -13,6 +13,7 @@ use ClaudioDekker\LaravelAuth\Methods\WebAuthn\Objects\CredentialAttributes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Session;
+use Mockery;
 
 trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
 {
@@ -364,6 +365,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         $this->expectTimeboxWithEarlyReturn();
         $this->preAuthenticate($userA, [$this->usernameField() => $userA->{$this->usernameField()}]);
         $this->mockPublicKeyRequestOptions([$credentialA]);
+        Mockery::close();
 
         // Next, instead of completing the challenge, the attacker will take their session id / CSRF tokens etc., and crafts
         // a manual 'login' attempt to that signs in the victim, which returns a redirect to the victim's MFA challenge.

--- a/packages/core/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingPublicKeyCredentialTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingPublicKeyCredentialTests.php
@@ -27,7 +27,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -206,7 +206,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         ]);
         $this->preAuthenticate($user, ['remember' => 'on']);
         $this->mockPublicKeyRequestOptions([$credential]);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -243,7 +243,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -282,7 +282,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -320,7 +320,7 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         $this->preAuthenticate($user);
         $this->assertNotEmpty($previousId = session()->getId());
         $this->mockPublicKeyRequestOptions([$credential]);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -361,13 +361,13 @@ trait SubmitMultiFactorChallengeUsingPublicKeyCredentialTests
         // This step emulates the attacker signing in to their account, but not completing the public-key credential challenge.
         // This places the public key challenge request object in the session, which includes all the allowed credentials.
         // (While we're not actually using the endpoints directly, the effect is identical when crafting requests)
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
         $this->preAuthenticate($userA, [$this->usernameField() => $userA->{$this->usernameField()}]);
         $this->mockPublicKeyRequestOptions([$credentialA]);
 
         // Next, instead of completing the challenge, the attacker will take their session id / CSRF tokens etc., and crafts
         // a manual 'login' attempt to that signs in the victim, which returns a redirect to the victim's MFA challenge.
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
         $craftedLogin = $this->preAuthenticate($userB, [$this->usernameField() => $userB->{$this->usernameField()}]);
         $craftedLogin->assertExactJson(['redirect_url' => route('login.challenge.multi_factor')]);
 

--- a/packages/core/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingTotpCodeTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingTotpCodeTests.php
@@ -24,6 +24,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create();
         $this->preAuthenticate($user);
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'));
 
@@ -39,6 +40,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create();
         $this->preAuthenticate($user);
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), ['code' => true]);
 
@@ -55,6 +57,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E']);
         $this->preAuthenticate($user);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),
@@ -76,6 +79,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => strrev($secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E')]);
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret]);
         $this->preAuthenticate($user);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),
@@ -96,6 +100,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->create(['secret' => $secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E']);
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => strrev($secret)]);
         $this->preAuthenticate($user);
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),
@@ -116,6 +121,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E']);
         $this->preAuthenticate($user);
         Cache::put('auth.mfa.totp_timestamps.'.$user->getAuthIdentifier(), (int) floor(microtime(true) / 30));
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),
@@ -135,6 +141,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E']);
         $this->preAuthenticate($user, ['remember' => 'on']);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),
@@ -156,6 +163,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E']);
         $this->preAuthenticate($user);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),
@@ -179,6 +187,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E']);
         $this->preAuthenticate($user);
         $this->assertNotEmpty($previousId = session()->getId());
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),

--- a/packages/core/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingTotpCodeTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/MultiFactor/SubmitMultiFactorChallengeUsingTotpCodeTests.php
@@ -57,7 +57,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E']);
         $this->preAuthenticate($user);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),
@@ -79,7 +79,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => strrev($secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E')]);
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret]);
         $this->preAuthenticate($user);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),
@@ -141,7 +141,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E']);
         $this->preAuthenticate($user, ['remember' => 'on']);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),
@@ -163,7 +163,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E']);
         $this->preAuthenticate($user);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),
@@ -187,7 +187,7 @@ trait SubmitMultiFactorChallengeUsingTotpCodeTests
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E']);
         $this->preAuthenticate($user);
         $this->assertNotEmpty($previousId = session()->getId());
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),

--- a/packages/core/src/Testing/Partials/Challenges/MultiFactor/ViewMultiFactorChallengePageTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/MultiFactor/ViewMultiFactorChallengePageTests.php
@@ -24,6 +24,7 @@ trait ViewMultiFactorChallengePageTests
         Config::set('laravel-auth.webauthn.relying_party.id', $rpId = 'configured.rpid');
         Config::set('laravel-auth.webauthn.timeout', $timeout = 12345);
         $this->mockWebauthnChallenge($challenge = 'cPMfYjCIb804eqvknNWAqA');
+        $this->expectTimebox();
 
         $response = $this->get(route('login.challenge.multi_factor'));
 
@@ -52,6 +53,7 @@ trait ViewMultiFactorChallengePageTests
         $response = $this->preAuthenticate($user);
         $response->assertExactJson(['redirect_url' => route('login.challenge.multi_factor')]);
         $this->assertFalse(Session::has('laravel-auth::public_key_challenge_request_options'));
+        $this->expectTimebox();
 
         $response = $this->get(route('login.challenge.multi_factor'));
 
@@ -69,6 +71,7 @@ trait ViewMultiFactorChallengePageTests
         $intendedLocation = session()->get('auth.mfa.intended_location');
         $response->assertExactJson(['redirect_url' => route('login.challenge.multi_factor')]);
         $credential->delete();
+        $this->expectTimebox();
 
         $response = $this->get(route('login.challenge.multi_factor'));
 

--- a/packages/core/src/Testing/Partials/Challenges/Recovery/SubmitAccountRecoveryChallengeTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/Recovery/SubmitAccountRecoveryChallengeTests.php
@@ -24,6 +24,7 @@ trait SubmitAccountRecoveryChallengeTests
         $repository = Password::getRepository();
         $token = $repository->create($user);
         $this->assertTrue($repository->exists($user, $token));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => $user->getEmailForPasswordReset(),
@@ -51,6 +52,7 @@ trait SubmitAccountRecoveryChallengeTests
         $repository = Password::getRepository();
         $token = $repository->create($user);
         $this->assertTrue($repository->exists($user, $token));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => $user->getEmailForPasswordReset(),
@@ -98,6 +100,7 @@ trait SubmitAccountRecoveryChallengeTests
         $user = $this->generateUser(['recovery_codes' => $codes = ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $repository = Password::getRepository();
         $token = $repository->create($user);
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => 'nonexistent-user@example.com',
@@ -123,6 +126,7 @@ trait SubmitAccountRecoveryChallengeTests
         $userB = $this->generateUser(['id' => 2, 'email' => 'another@example.com', 'recovery_codes' => $codes, $this->usernameField() => $this->anotherUsername()]);
         $repository = Password::getRepository();
         $token = $repository->create($userA);
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => $userB->getEmailForPasswordReset(),
@@ -147,6 +151,7 @@ trait SubmitAccountRecoveryChallengeTests
         $user = $this->generateUser(['recovery_codes' => $codes = ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $repository = Password::getRepository();
         $token = $repository->create($user);
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => 'invalid-token']), [
             'email' => $user->getEmailForPasswordReset(),
@@ -172,6 +177,7 @@ trait SubmitAccountRecoveryChallengeTests
         $repository = Password::getRepository();
         $token = $repository->create($user);
         $this->assertTrue($repository->exists($user, $token));
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => $user->getEmailForPasswordReset(),

--- a/packages/core/src/Testing/Partials/Challenges/Recovery/SubmitAccountRecoveryChallengeTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/Recovery/SubmitAccountRecoveryChallengeTests.php
@@ -24,7 +24,7 @@ trait SubmitAccountRecoveryChallengeTests
         $repository = Password::getRepository();
         $token = $repository->create($user);
         $this->assertTrue($repository->exists($user, $token));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => $user->getEmailForPasswordReset(),
@@ -52,7 +52,7 @@ trait SubmitAccountRecoveryChallengeTests
         $repository = Password::getRepository();
         $token = $repository->create($user);
         $this->assertTrue($repository->exists($user, $token));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => $user->getEmailForPasswordReset(),

--- a/packages/core/src/Testing/Partials/Challenges/Recovery/ViewAccountRecoveryChallengePageTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/Recovery/ViewAccountRecoveryChallengePageTests.php
@@ -19,7 +19,7 @@ trait ViewAccountRecoveryChallengePageTests
     {
         $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $token = Password::getRepository()->create($user);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->get(route('recover-account.challenge', [
             'token' => $token,
@@ -38,7 +38,7 @@ trait ViewAccountRecoveryChallengePageTests
         $repository = Password::getRepository();
         $token = $repository->create($user);
         $this->assertTrue($repository->exists($user, $token));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->get(route('recover-account.challenge', [
             'token' => $token,

--- a/packages/core/src/Testing/Partials/Challenges/Recovery/ViewAccountRecoveryChallengePageTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/Recovery/ViewAccountRecoveryChallengePageTests.php
@@ -19,6 +19,7 @@ trait ViewAccountRecoveryChallengePageTests
     {
         $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $token = Password::getRepository()->create($user);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->get(route('recover-account.challenge', [
             'token' => $token,
@@ -37,6 +38,7 @@ trait ViewAccountRecoveryChallengePageTests
         $repository = Password::getRepository();
         $token = $repository->create($user);
         $this->assertTrue($repository->exists($user, $token));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->get(route('recover-account.challenge', [
             'token' => $token,
@@ -70,6 +72,7 @@ trait ViewAccountRecoveryChallengePageTests
     {
         $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $token = Password::getRepository()->create($user);
+        $this->expectTimebox();
 
         $response = $this->get(route('recover-account.challenge', [
             'token' => $token,
@@ -87,6 +90,7 @@ trait ViewAccountRecoveryChallengePageTests
         $userA = $this->generateUser(['id' => 1, 'email' => 'claudio@ubient.net', 'recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $userB = $this->generateUser(['id' => 2, 'email' => 'another@example.com', $this->usernameField() => $this->anotherUsername(), 'recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $token = Password::getRepository()->create($userA);
+        $this->expectTimebox();
 
         $response = $this->get(route('recover-account.challenge', [
             'token' => $token,
@@ -102,6 +106,7 @@ trait ViewAccountRecoveryChallengePageTests
     public function the_account_recovery_challenge_page_cannot_be_viewed_when_the_recovery_token_does_not_exist(): void
     {
         $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
+        $this->expectTimebox();
 
         $response = $this->get(route('recover-account.challenge', [
             'token' => 'invalid-token',
@@ -120,6 +125,7 @@ trait ViewAccountRecoveryChallengePageTests
         $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT', 'GPP13-AEXMR', 'WGAHD-95VNQ', 'BSFYG-VFG2N', 'AWOPQ-NWYJX', '2PVJM-QHPBM', 'STR7J-5ND0P']]);
         $token = Password::getRepository()->create($user);
         Carbon::setTestNow(now()->addHour()->addSecond());
+        $this->expectTimebox();
 
         $response = $this->get(route('recover-account.challenge', [
             'token' => $token,

--- a/packages/core/src/Testing/Partials/Challenges/SudoMode/ConfirmSudoModeUsingCredentialTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/SudoMode/ConfirmSudoModeUsingCredentialTests.php
@@ -32,7 +32,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $this->mockWebauthnChallenge('G0JbLLndef3a0Iy3S2sSQA8uO4SO/ze6FZMAuPI6+xI=');
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -199,7 +199,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $this->mockWebauthnChallenge('R9KnmyTxs6zHJB75bhLKgw');
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [

--- a/packages/core/src/Testing/Partials/Challenges/SudoMode/ConfirmSudoModeUsingCredentialTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/SudoMode/ConfirmSudoModeUsingCredentialTests.php
@@ -32,6 +32,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $this->mockWebauthnChallenge('G0JbLLndef3a0Iy3S2sSQA8uO4SO/ze6FZMAuPI6+xI=');
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -72,6 +73,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $this->mockWebauthnChallenge('G0JbLLndef3a0Iy3S2sSQA8uO4SO/ze6FZMAuPI6+xI=');
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->expectTimebox();
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -111,6 +113,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $this->mockWebauthnChallenge('G0JbLLndef3a0Iy3S2sSQA8uO4SO/ze6FZMAuPI6+xI=');
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->expectTimebox();
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -155,6 +158,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $this->mockWebauthnChallenge('G0JbLLndef3a0Iy3S2sSQA8uO4SO/ze6FZMAuPI6+xI=');
         $this->actingAs($userA)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->expectTimebox();
 
         $response = $this->actingAs($userA)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -195,6 +199,7 @@ trait ConfirmSudoModeUsingCredentialTests
         $this->mockWebauthnChallenge('R9KnmyTxs6zHJB75bhLKgw');
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -232,6 +237,7 @@ trait ConfirmSudoModeUsingCredentialTests
             'id' => 'public-key-eHouz_Zi7-BmByHjJ_tx9h4a1WZsK4IzUmgGjkhyOodPGAyUqUp_B9yUkflXY3yHWsNtsrgCXQ3HjAIFUeZB-w',
             'secret' => '{"id":"eHouz/Zi7+BmByHjJ/tx9h4a1WZsK4IzUmgGjkhyOodPGAyUqUp/B9yUkflXY3yHWsNtsrgCXQ3HjAIFUeZB+w==","publicKey":"pQECAyYgASFYIJV56vRrFusoDf9hm3iDmllcxxXzzKyO9WruKw4kWx7zIlgg/nq63l8IMJcIdKDJcXRh9hoz0L+nVwP1Oxil3/oNQYs=","signCount":117,"userHandle":"1","transports":[]}',
         ]);
+        $this->expectTimebox();
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -263,6 +269,7 @@ trait ConfirmSudoModeUsingCredentialTests
         Carbon::setTestNow(now());
         $user = $this->generateUser();
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
+        $this->expectTimebox();
 
         $response = $this->actingAs($user)
             ->from(route('auth.sudo_mode'))

--- a/packages/core/src/Testing/Partials/Challenges/SudoMode/ConfirmSudoModeUsingPasswordTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/SudoMode/ConfirmSudoModeUsingPasswordTests.php
@@ -22,6 +22,7 @@ trait ConfirmSudoModeUsingPasswordTests
         $user = $this->generateUser();
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $this->actingAs($user)->get(route('auth.sudo_mode'));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->actingAs($user)
             ->post(route('auth.sudo_mode'), [
@@ -44,6 +45,7 @@ trait ConfirmSudoModeUsingPasswordTests
         Carbon::setTestNow(now());
         $user = $this->generateUser();
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
+        $this->expectTimebox();
 
         $response = $this->actingAs($user)
             ->from(route('auth.sudo_mode'))
@@ -85,6 +87,7 @@ trait ConfirmSudoModeUsingPasswordTests
         Carbon::setTestNow(now());
         $user = $this->generateUser(['has_password' => false]);
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
+        $this->expectTimebox();
 
         $response = $this->actingAs($user)
             ->post(route('auth.sudo_mode'), [

--- a/packages/core/src/Testing/Partials/Challenges/SudoMode/ConfirmSudoModeUsingPasswordTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/SudoMode/ConfirmSudoModeUsingPasswordTests.php
@@ -22,7 +22,7 @@ trait ConfirmSudoModeUsingPasswordTests
         $user = $this->generateUser();
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $this->actingAs($user)->get(route('auth.sudo_mode'));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->actingAs($user)
             ->post(route('auth.sudo_mode'), [

--- a/packages/core/src/Testing/Partials/Challenges/SudoMode/ViewSudoModeChallengePageTests.php
+++ b/packages/core/src/Testing/Partials/Challenges/SudoMode/ViewSudoModeChallengePageTests.php
@@ -15,6 +15,7 @@ trait ViewSudoModeChallengePageTests
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->publicKey()->forUser($user)->create();
         $this->assertFalse(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->expectTimebox();
 
         $response = $this->actingAs($user)->get(route('auth.sudo_mode'));
 
@@ -28,6 +29,7 @@ trait ViewSudoModeChallengePageTests
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $user = $this->generateUser();
         $this->assertFalse(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
+        $this->expectTimebox();
 
         $response = $this->actingAs($user)->get(route('auth.sudo_mode'));
 

--- a/packages/core/src/Testing/Partials/RateLimiting/AccountRecoveryChallengeRateLimitingTests.php
+++ b/packages/core/src/Testing/Partials/RateLimiting/AccountRecoveryChallengeRateLimitingTests.php
@@ -38,6 +38,7 @@ trait AccountRecoveryChallengeRateLimitingTests
         $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT']]);
         $token = Password::getRepository()->create($user);
         $this->assertSame(0, $this->getRateLimitAttempts($ipKey = 'ip::127.0.0.1'));
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => 'nonexistent-user@example.com',
@@ -57,6 +58,7 @@ trait AccountRecoveryChallengeRateLimitingTests
         $userB = $this->generateUser(['id' => 2, 'email' => 'another@example.com', $this->usernameField() => $this->anotherUsername()]);
         $token = Password::getRepository()->create($userA);
         $this->assertSame(0, $this->getRateLimitAttempts($ipKey = 'ip::127.0.0.1'));
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => $userB->getEmailForPasswordReset(),
@@ -74,6 +76,7 @@ trait AccountRecoveryChallengeRateLimitingTests
     {
         $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT']]);
         $this->assertSame(0, $this->getRateLimitAttempts($ipKey = 'ip::127.0.0.1'));
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => 'invalid-token']), [
             'email' => $user->getEmailForPasswordReset(),
@@ -93,6 +96,7 @@ trait AccountRecoveryChallengeRateLimitingTests
         $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT']]);
         $token = Password::getRepository()->create($user);
         $this->assertSame(0, $this->getRateLimitAttempts($ipKey = 'ip::127.0.0.1'));
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => $user->getEmailForPasswordReset(),
@@ -115,6 +119,7 @@ trait AccountRecoveryChallengeRateLimitingTests
         $this->hitRateLimiter(1, $ipKey = 'ip::127.0.0.1');
         $this->assertSame(1, $this->getRateLimitAttempts(''));
         $this->assertSame(1, $this->getRateLimitAttempts($ipKey));
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => $user->getEmailForPasswordReset(),

--- a/packages/core/src/Testing/Partials/RateLimiting/AccountRecoveryChallengeWithoutRateLimitingTests.php
+++ b/packages/core/src/Testing/Partials/RateLimiting/AccountRecoveryChallengeWithoutRateLimitingTests.php
@@ -20,6 +20,7 @@ trait AccountRecoveryChallengeWithoutRateLimitingTests
         $mock = RateLimiter::partialMock();
         $mock->shouldNotReceive('tooManyAttempts');
         $mock->shouldNotReceive('availableIn');
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => $user->getEmailForPasswordReset(),
@@ -37,6 +38,7 @@ trait AccountRecoveryChallengeWithoutRateLimitingTests
         $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT']]);
         $token = Password::getRepository()->create($user);
         $this->assertSame(0, RateLimiter::attempts($throttlingKey = 'account-recovery-challenge|127.0.0.1'));
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => 'nonexistent-user@example.com',
@@ -56,6 +58,7 @@ trait AccountRecoveryChallengeWithoutRateLimitingTests
         $userB = $this->generateUser(['id' => 2, 'email' => 'another@example.com', $this->usernameField() => $this->anotherUsername()]);
         $token = Password::getRepository()->create($userA);
         $this->assertSame(0, RateLimiter::attempts($throttlingKey = 'account-recovery-challenge|127.0.0.1'));
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => $userB->getEmailForPasswordReset(),
@@ -73,6 +76,7 @@ trait AccountRecoveryChallengeWithoutRateLimitingTests
     {
         $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT']]);
         $this->assertSame(0, RateLimiter::attempts($throttlingKey = 'account-recovery-challenge|127.0.0.1'));
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => 'invalid-token']), [
             'email' => $user->getEmailForPasswordReset(),
@@ -91,6 +95,7 @@ trait AccountRecoveryChallengeWithoutRateLimitingTests
         $user = $this->generateUser(['recovery_codes' => ['H4PFK-ENVZV', 'PIPIM-7LTUT']]);
         $token = Password::getRepository()->create($user);
         $this->assertSame(0, RateLimiter::attempts($throttlingKey = 'account-recovery-challenge|127.0.0.1'));
+        $this->expectTimebox();
 
         $response = $this->post(route('recover-account.challenge', ['token' => $token]), [
             'email' => $user->getEmailForPasswordReset(),

--- a/packages/core/src/Testing/Partials/RateLimiting/AccountRecoveryRequestRateLimitingTests.php
+++ b/packages/core/src/Testing/Partials/RateLimiting/AccountRecoveryRequestRateLimitingTests.php
@@ -34,6 +34,7 @@ trait AccountRecoveryRequestRateLimitingTests
     {
         $this->assertSame(0, $this->getRateLimitAttempts('ip::127.0.0.1'));
         $this->assertSame(0, $this->getRateLimitAttempts(''));
+        $this->expectTimebox();
 
         $this->post(route('recover-account'), [
             'email' => 'foo@example.com',

--- a/packages/core/src/Testing/Partials/RateLimiting/AccountRecoveryRequestWithoutRateLimitingTests.php
+++ b/packages/core/src/Testing/Partials/RateLimiting/AccountRecoveryRequestWithoutRateLimitingTests.php
@@ -13,6 +13,7 @@ trait AccountRecoveryRequestWithoutRateLimitingTests
     {
         Event::fake(Lockout::class);
         $mock = RateLimiter::spy();
+        $this->expectTimebox();
 
         $response = $this->from('/foo')->post(route('recover-account'), [
             'email' => 'foo@example.com',
@@ -29,6 +30,7 @@ trait AccountRecoveryRequestWithoutRateLimitingTests
     public function account_recovery_requests_do_not_increment_the_rate_limiting_attempts(): void
     {
         $mock = RateLimiter::spy();
+        $this->expectTimebox();
 
         $response = $this->from('/foo')->post(route('recover-account'), [
             'email' => 'foo@example.com',

--- a/packages/core/src/Testing/Partials/RateLimiting/LoginRateLimitingTests.php
+++ b/packages/core/src/Testing/Partials/RateLimiting/LoginRateLimitingTests.php
@@ -21,7 +21,6 @@ trait LoginRateLimitingTests
         Carbon::setTestNow(now());
         Event::fake([Lockout::class, Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $this->hitRateLimiter(250, '');
-        $this->expectTimebox();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
@@ -41,7 +40,6 @@ trait LoginRateLimitingTests
         Carbon::setTestNow(now());
         Event::fake([Lockout::class, Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $this->hitRateLimiter(5, 'ip::127.0.0.1');
-        $this->expectTimebox();
 
         $responseA = $this->submitPasswordBasedLoginAttempt();
 
@@ -52,8 +50,6 @@ trait LoginRateLimitingTests
         Event::assertNotDispatched(Authenticated::class);
         Event::assertNotDispatched(AuthenticationFailed::class);
         Event::assertNotDispatched(MultiFactorChallenged::class);
-
-        $this->expectTimebox();
 
         $responseB = $this->submitPasswordBasedLoginAttempt([$this->usernameField() => $this->nonExistentUsername()]);
         $this->assertInstanceOf(ValidationException::class, $responseB->exception);
@@ -67,7 +63,6 @@ trait LoginRateLimitingTests
         Carbon::setTestNow(now());
         Event::fake([Lockout::class, Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $this->hitRateLimiter(5, 'username::'.$this->defaultUsername());
-        $this->expectTimebox();
 
         $responseA = $this->submitPasswordBasedLoginAttempt();
 
@@ -116,7 +111,7 @@ trait LoginRateLimitingTests
         $this->assertSame(1, $this->getRateLimitAttempts(''));
         $this->assertSame(1, $this->getRateLimitAttempts($usernameKey));
         $this->assertSame(1, $this->getRateLimitAttempts($ipKey));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
@@ -134,7 +129,6 @@ trait LoginRateLimitingTests
         Carbon::setTestNow(now());
         Event::fake([Lockout::class, Authenticated::class, AuthenticationFailed::class]);
         $this->hitRateLimiter(250, '');
-        $this->expectTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -166,7 +160,6 @@ trait LoginRateLimitingTests
         Carbon::setTestNow(now());
         Event::fake([Lockout::class, Authenticated::class, AuthenticationFailed::class]);
         $this->hitRateLimiter(5, 'ip::127.0.0.1');
-        $this->expectTimebox();
 
         $responseA = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -235,7 +228,7 @@ trait LoginRateLimitingTests
         $this->hitRateLimiter(1, $ipKey = 'ip::127.0.0.1');
         $this->assertSame(1, $this->getRateLimitAttempts(''));
         $this->assertSame(1, $this->getRateLimitAttempts($ipKey));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',

--- a/packages/core/src/Testing/Partials/RateLimiting/LoginWithoutRateLimitingTests.php
+++ b/packages/core/src/Testing/Partials/RateLimiting/LoginWithoutRateLimitingTests.php
@@ -17,6 +17,7 @@ trait LoginWithoutRateLimitingTests
         $mock = RateLimiter::partialMock();
         $mock->shouldNotReceive('tooManyAttempts');
         $mock->shouldNotReceive('availableIn');
+        $this->expectTimebox();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
@@ -31,6 +32,7 @@ trait LoginWithoutRateLimitingTests
     {
         $mock = RateLimiter::partialMock();
         $mock->shouldNotReceive('tooManyAttempts');
+        $this->expectTimebox();
 
         $this->submitPasswordBasedLoginAttempt();
     }
@@ -42,6 +44,7 @@ trait LoginWithoutRateLimitingTests
         $mock = RateLimiter::partialMock();
         $mock->shouldNotReceive('tooManyAttempts');
         $mock->shouldNotReceive('availableIn');
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -69,6 +72,7 @@ trait LoginWithoutRateLimitingTests
     {
         $mock = RateLimiter::partialMock();
         $mock->shouldNotReceive('tooManyAttempts');
+        $this->expectTimebox();
 
         $this->postJson(route('login'), [
             'type' => 'passkey',

--- a/packages/core/src/Testing/Partials/RateLimiting/MultiFactorChallengeRateLimitingTests.php
+++ b/packages/core/src/Testing/Partials/RateLimiting/MultiFactorChallengeRateLimitingTests.php
@@ -27,7 +27,6 @@ trait MultiFactorChallengeRateLimitingTests
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
         $this->hitRateLimiter(5, 'ip::127.0.0.1');
-        $this->expectTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -61,7 +60,6 @@ trait MultiFactorChallengeRateLimitingTests
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create();
         $this->preAuthenticate($user);
         $this->hitRateLimiter(5, 'ip::127.0.0.1');
-        $this->expectTimebox();
 
         $response = $this->from(route('login.challenge.multi_factor'))->post(route('login.challenge.multi_factor'), ['code' => '123456']);
 
@@ -151,7 +149,7 @@ trait MultiFactorChallengeRateLimitingTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -189,7 +187,7 @@ trait MultiFactorChallengeRateLimitingTests
         $this->assertSame(1, $this->getRateLimitAttempts($ipKey));
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E']);
         $this->preAuthenticate($user);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->from(route('login.challenge.multi_factor'))->post(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),

--- a/packages/core/src/Testing/Partials/RateLimiting/MultiFactorChallengeRateLimitingTests.php
+++ b/packages/core/src/Testing/Partials/RateLimiting/MultiFactorChallengeRateLimitingTests.php
@@ -27,6 +27,7 @@ trait MultiFactorChallengeRateLimitingTests
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
         $this->hitRateLimiter(5, 'ip::127.0.0.1');
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -60,6 +61,7 @@ trait MultiFactorChallengeRateLimitingTests
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create();
         $this->preAuthenticate($user);
         $this->hitRateLimiter(5, 'ip::127.0.0.1');
+        $this->expectTimebox();
 
         $response = $this->from(route('login.challenge.multi_factor'))->post(route('login.challenge.multi_factor'), ['code' => '123456']);
 
@@ -86,6 +88,7 @@ trait MultiFactorChallengeRateLimitingTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -119,6 +122,7 @@ trait MultiFactorChallengeRateLimitingTests
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create();
         $this->preAuthenticate($user);
+        $this->expectTimebox();
 
         $response = $this->from(route('login.challenge.multi_factor'))->post(route('login.challenge.multi_factor'), ['code' => '123456']);
 
@@ -147,6 +151,7 @@ trait MultiFactorChallengeRateLimitingTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
             'credential' => [
@@ -184,6 +189,7 @@ trait MultiFactorChallengeRateLimitingTests
         $this->assertSame(1, $this->getRateLimitAttempts($ipKey));
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create(['secret' => $secret = '4DDDT7XUWA6QPM2ZXHAMPXFEOHSNYN5E']);
         $this->preAuthenticate($user);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->from(route('login.challenge.multi_factor'))->post(route('login.challenge.multi_factor'), [
             'code' => App::make(GoogleTwoFactorAuthenticator::class)->testCode($secret),

--- a/packages/core/src/Testing/Partials/RateLimiting/MultiFactorChallengeWithoutRateLimitingTests.php
+++ b/packages/core/src/Testing/Partials/RateLimiting/MultiFactorChallengeWithoutRateLimitingTests.php
@@ -23,6 +23,7 @@ trait MultiFactorChallengeWithoutRateLimitingTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
+        $this->expectTimebox();
         $mock = RateLimiter::spy();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
@@ -56,6 +57,7 @@ trait MultiFactorChallengeWithoutRateLimitingTests
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create();
         $this->preAuthenticate($user);
+        $this->expectTimebox();
         $mock = RateLimiter::spy();
 
         $response = $this->from(route('login.challenge.multi_factor'))->post(route('login.challenge.multi_factor'), ['code' => '123456']);
@@ -80,6 +82,7 @@ trait MultiFactorChallengeWithoutRateLimitingTests
         ]);
         $this->preAuthenticate($user);
         $this->mockPublicKeyRequestOptions([$credential]);
+        $this->expectTimebox();
         $mock = RateLimiter::spy();
 
         $response = $this->postJson(route('login.challenge.multi_factor'), [
@@ -108,6 +111,7 @@ trait MultiFactorChallengeWithoutRateLimitingTests
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create();
         $this->preAuthenticate($user);
+        $this->expectTimebox();
         $mock = RateLimiter::spy();
 
         $response = $this->from(route('login.challenge.multi_factor'))->post(route('login.challenge.multi_factor'), ['code' => '123456']);

--- a/packages/core/src/Testing/Partials/RateLimiting/SudoModeRateLimitingTests.php
+++ b/packages/core/src/Testing/Partials/RateLimiting/SudoModeRateLimitingTests.php
@@ -22,7 +22,6 @@ trait SudoModeRateLimitingTests
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $user = $this->generateUser(['id' => 1]);
         $this->hitRateLimiter(5, 'ip::127.0.0.1');
-        $this->expectTimebox();
 
         $response = $this->actingAs($user)->post(route('auth.sudo_mode'), [
             'password' => 'password',
@@ -43,7 +42,6 @@ trait SudoModeRateLimitingTests
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $user = $this->generateUser(['id' => 1]);
         $this->hitRateLimiter(5, 'user_id::1');
-        $this->expectTimebox();
 
         $response = $this->actingAs($user)->post(route('auth.sudo_mode'), [
             'password' => 'password',
@@ -83,7 +81,7 @@ trait SudoModeRateLimitingTests
         $user = $this->generateUser(['id' => 1]);
         $this->hitRateLimiter(1, $ipKey = 'ip::127.0.0.1');
         $this->hitRateLimiter(1, $userKey = 'user_id::1');
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $this->actingAs($user)->post(route('auth.sudo_mode'), [
             'password' => 'password',
@@ -106,7 +104,6 @@ trait SudoModeRateLimitingTests
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
         $this->hitRateLimiter(5, 'ip::127.0.0.1');
-        $this->expectTimebox();
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -140,7 +137,6 @@ trait SudoModeRateLimitingTests
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
         $this->hitRateLimiter(5, 'user_id::1');
-        $this->expectTimebox();
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -214,7 +210,7 @@ trait SudoModeRateLimitingTests
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
         $this->hitRateLimiter(1, $ipKey = 'ip::127.0.0.1');
         $this->hitRateLimiter(1, $userKey = 'user_id::1');
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [

--- a/packages/core/src/Testing/Partials/RateLimiting/SudoModeRateLimitingTests.php
+++ b/packages/core/src/Testing/Partials/RateLimiting/SudoModeRateLimitingTests.php
@@ -22,6 +22,7 @@ trait SudoModeRateLimitingTests
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $user = $this->generateUser(['id' => 1]);
         $this->hitRateLimiter(5, 'ip::127.0.0.1');
+        $this->expectTimebox();
 
         $response = $this->actingAs($user)->post(route('auth.sudo_mode'), [
             'password' => 'password',
@@ -42,6 +43,7 @@ trait SudoModeRateLimitingTests
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $user = $this->generateUser(['id' => 1]);
         $this->hitRateLimiter(5, 'user_id::1');
+        $this->expectTimebox();
 
         $response = $this->actingAs($user)->post(route('auth.sudo_mode'), [
             'password' => 'password',
@@ -62,6 +64,7 @@ trait SudoModeRateLimitingTests
         $user = $this->generateUser(['id' => 1]);
         $this->assertSame(0, $this->getRateLimitAttempts($ipKey = 'ip::127.0.0.1'));
         $this->assertSame(0, $this->getRateLimitAttempts($userKey = 'user_id::1'));
+        $this->expectTimebox();
 
         $this->actingAs($user)->post(route('auth.sudo_mode'), [
             'password' => 'invalid-password',
@@ -80,6 +83,7 @@ trait SudoModeRateLimitingTests
         $user = $this->generateUser(['id' => 1]);
         $this->hitRateLimiter(1, $ipKey = 'ip::127.0.0.1');
         $this->hitRateLimiter(1, $userKey = 'user_id::1');
+        $this->expectSuccessfulTimebox();
 
         $this->actingAs($user)->post(route('auth.sudo_mode'), [
             'password' => 'password',
@@ -102,6 +106,7 @@ trait SudoModeRateLimitingTests
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
         $this->hitRateLimiter(5, 'ip::127.0.0.1');
+        $this->expectTimebox();
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -135,6 +140,7 @@ trait SudoModeRateLimitingTests
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
         $this->hitRateLimiter(5, 'user_id::1');
+        $this->expectTimebox();
 
         $response = $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -169,6 +175,7 @@ trait SudoModeRateLimitingTests
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
         $this->assertSame(0, $this->getRateLimitAttempts($ipKey = 'ip::127.0.0.1'));
         $this->assertSame(0, $this->getRateLimitAttempts($userKey = 'user_id::1'));
+        $this->expectTimebox();
 
         $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -207,6 +214,7 @@ trait SudoModeRateLimitingTests
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
         $this->hitRateLimiter(1, $ipKey = 'ip::127.0.0.1');
         $this->hitRateLimiter(1, $userKey = 'user_id::1');
+        $this->expectSuccessfulTimebox();
 
         $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [

--- a/packages/core/src/Testing/Partials/RateLimiting/SudoModeWithoutRateLimitingTests.php
+++ b/packages/core/src/Testing/Partials/RateLimiting/SudoModeWithoutRateLimitingTests.php
@@ -21,6 +21,7 @@ trait SudoModeWithoutRateLimitingTests
         $mock = RateLimiter::partialMock();
         $mock->shouldNotReceive('tooManyAttempts');
         $mock->shouldNotReceive('availableIn');
+        $this->expectTimebox();
 
         $this->actingAs($user)->post(route('auth.sudo_mode'), [
             'password' => 'invalid-password',
@@ -36,6 +37,7 @@ trait SudoModeWithoutRateLimitingTests
         Session::put(EnsureSudoMode::REQUIRED_AT_KEY, now()->unix());
         $user = $this->generateUser();
         $mock = RateLimiter::spy();
+        $this->expectTimebox();
 
         $this->actingAs($user)->post(route('auth.sudo_mode'), [
             'password' => 'invalid-password',
@@ -58,6 +60,7 @@ trait SudoModeWithoutRateLimitingTests
         $mock = RateLimiter::partialMock();
         $mock->shouldNotReceive('tooManyAttempts');
         $mock->shouldNotReceive('availableIn');
+        $this->expectTimebox();
 
         $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [
@@ -86,6 +89,7 @@ trait SudoModeWithoutRateLimitingTests
         $this->actingAs($user)->get(route('auth.sudo_mode'));
         $this->assertTrue(Session::has('laravel-auth::sudo_mode.public_key_challenge_request_options'));
         $mock = RateLimiter::spy();
+        $this->expectTimebox();
 
         $this->actingAs($user)->postJson(route('auth.sudo_mode'), [
             'credential' => [

--- a/packages/core/src/Testing/Partials/SubmitAccountRecoveryRequestTests.php
+++ b/packages/core/src/Testing/Partials/SubmitAccountRecoveryRequestTests.php
@@ -19,6 +19,7 @@ trait SubmitAccountRecoveryRequestTests
         Notification::fake();
         $repository = Password::getRepository();
         $user = $this->generateUser();
+        $this->expectTimebox();
 
         $response = $this->from('/foo')->post(route('recover-account'), [
             'email' => $user->email,
@@ -58,6 +59,7 @@ trait SubmitAccountRecoveryRequestTests
     public function it_validates_that_the_email_is_required_when_requesting_an_account_recovery_link(): void
     {
         Notification::fake();
+        $this->expectTimebox();
 
         $response = $this->from('/foo')->post(route('recover-account'), [
             'email' => '',
@@ -73,6 +75,7 @@ trait SubmitAccountRecoveryRequestTests
     public function it_cannot_send_an_account_recovery_link_to_an_user_that_does_not_exist(): void
     {
         Notification::fake();
+        $this->expectTimebox();
 
         $response = $this->from('/foo')->post(route('recover-account'), [
             'email' => 'foo@example.com',
@@ -93,6 +96,7 @@ trait SubmitAccountRecoveryRequestTests
         $repository->create($user);
         Carbon::setTestNow(now()->addSeconds(59));
         $this->assertTrue($repository->recentlyCreatedToken($user));
+        $this->expectTimebox();
 
         $response = $this->from('/foo')->post(route('recover-account'), [
             'email' => $user->email,

--- a/packages/core/src/Testing/Partials/SubmitPasskeyBasedAuthenticationTests.php
+++ b/packages/core/src/Testing/Partials/SubmitPasskeyBasedAuthenticationTests.php
@@ -28,7 +28,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -272,7 +272,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ID\/CFbjp7mfDuI4zwEe+49\/g1+8=","publicKey":"pQECAyYgASFYIFZSx3fc0szMDz38Eu4ZBWjeAQMP0dWR\/D+Dy3RA1tktIlggJzLmQt5ydTQ6PXRF4GFCgWyXJBT0giypbK0wducMmW4=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptionsTwo()));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -385,7 +385,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -424,7 +424,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -462,7 +462,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -502,7 +502,7 @@ trait SubmitPasskeyBasedAuthenticationTests
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
         $this->assertNotEmpty($previousId = session()->getId());
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',

--- a/packages/core/src/Testing/Partials/SubmitPasskeyBasedAuthenticationTests.php
+++ b/packages/core/src/Testing/Partials/SubmitPasskeyBasedAuthenticationTests.php
@@ -28,6 +28,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -74,6 +75,7 @@ trait SubmitPasskeyBasedAuthenticationTests
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $this->generateUser(['id' => 1, 'has_password' => false]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -95,6 +97,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'id' => 'public-key-ea2KxTIqiH6GqbKePv4rwk8XWVE',
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -127,6 +130,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -162,6 +166,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptionsTwo()));
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -193,6 +198,7 @@ trait SubmitPasskeyBasedAuthenticationTests
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $this->generateUser(['id' => 1, 'has_password' => false]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -228,6 +234,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"2","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -265,6 +272,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ID\/CFbjp7mfDuI4zwEe+49\/g1+8=","publicKey":"pQECAyYgASFYIFZSx3fc0szMDz38Eu4ZBWjeAQMP0dWR\/D+Dy3RA1tktIlggJzLmQt5ydTQ6PXRF4GFCgWyXJBT0giypbK0wducMmW4=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptionsTwo()));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -303,6 +311,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ID\/CFbjp7mfDuI4zwEe+49\/g1+8=","publicKey":"pQECAyYgASFYIFZSx3fc0szMDz38Eu4ZBWjeAQMP0dWR\/D+Dy3RA1tktIlggJzLmQt5ydTQ6PXRF4GFCgWyXJBT0giypbK0wducMmW4=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptionsTwo()));
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -340,6 +349,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ID\/CFbjp7mfDuI4zwEe+49\/g1+8=","publicKey":"pQECAyYgASFYIFZSx3fc0szMDz38Eu4ZBWjeAQMP0dWR\/D+Dy3RA1tktIlggJzLmQt5ydTQ6PXRF4GFCgWyXJBT0giypbK0wducMmW4=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptionsTwo()));
+        $this->expectTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -375,6 +385,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -413,6 +424,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -450,6 +462,7 @@ trait SubmitPasskeyBasedAuthenticationTests
             'secret' => '{"id":"ea2KxTIqiH6GqbKePv4rwk8XWVE=","publicKey":"pQECAyYgASFYIEOExHX5IQpnF2dCG1fpw51gD7va0WxmKonfkDMWIRG9Ilggj7YxOrVEYp6EAeGNYwOlpd8FUmsqYyk0L0JIpNa1\/3A=","signCount":0,"userHandle":"1","transports":[]}',
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',
@@ -489,6 +502,7 @@ trait SubmitPasskeyBasedAuthenticationTests
         ]);
         Session::put('auth.login.passkey_authentication_options', serialize($this->mockPasskeyRequestOptions()));
         $this->assertNotEmpty($previousId = session()->getId());
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('login'), [
             'type' => 'passkey',

--- a/packages/core/src/Testing/Partials/SubmitPasskeyBasedRegistrationTests.php
+++ b/packages/core/src/Testing/Partials/SubmitPasskeyBasedRegistrationTests.php
@@ -206,7 +206,7 @@ trait SubmitPasskeyBasedRegistrationTests
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         $options = $this->mockPasskeyCreationOptions($user);
         Session::put('auth.register.passkey_creation_options', serialize($options));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->submitPasskeyBasedRegisterAttempt();
 
@@ -315,7 +315,7 @@ trait SubmitPasskeyBasedRegistrationTests
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         $options = $this->mockPasskeyCreationOptionsTwo($user);
         Session::put('auth.register.passkey_creation_options', serialize($options));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->postJson(route('register'), [
             'type' => 'passkey',
@@ -417,7 +417,7 @@ trait SubmitPasskeyBasedRegistrationTests
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         $options = $this->mockPasskeyCreationOptions($user);
         Session::put('auth.register.passkey_creation_options', serialize($options));
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->submitPasskeyBasedRegisterAttempt();
 

--- a/packages/core/src/Testing/Partials/SubmitPasskeyBasedRegistrationTests.php
+++ b/packages/core/src/Testing/Partials/SubmitPasskeyBasedRegistrationTests.php
@@ -26,6 +26,7 @@ trait SubmitPasskeyBasedRegistrationTests
         Config::set('laravel-auth.webauthn.relying_party.id', 'localhost');
         Config::set('laravel-auth.webauthn.relying_party.name', 'Laravel Auth Package');
         $this->assertCount(0, LaravelAuth::userModel()::all());
+        $this->expectTimebox();
         $response = $this->initializePasskeyBasedRegisterAttempt();
 
         $this->assertGuest();
@@ -86,6 +87,8 @@ trait SubmitPasskeyBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_name_is_required_when_initializing_passkey_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->initializePasskeyBasedRegisterAttempt(['name' => '']);
 
         $response->assertSessionMissing('auth.register.passkey_creation_options');
@@ -97,6 +100,8 @@ trait SubmitPasskeyBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_name_is_a_string_when_initializing_passkey_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->initializePasskeyBasedRegisterAttempt(['name' => 123]);
 
         $response->assertSessionMissing('auth.register.passkey_creation_options');
@@ -108,6 +113,8 @@ trait SubmitPasskeyBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_name_does_not_exceed_255_characters_when_initializing_passkey_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->initializePasskeyBasedRegisterAttempt(['name' => str_repeat('a', 256)]);
 
         $response->assertSessionMissing('auth.register.passkey_creation_options');
@@ -119,6 +126,8 @@ trait SubmitPasskeyBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_username_is_required_when_initializing_passkey_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->initializePasskeyBasedRegisterAttempt([$this->usernameField() => '']);
 
         $response->assertSessionMissing('auth.register.passkey_creation_options');
@@ -129,6 +138,8 @@ trait SubmitPasskeyBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_username_does_not_exceed_255_characters_when_initializing_passkey_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->initializePasskeyBasedRegisterAttempt([$this->usernameField() => $this->tooLongUsername()]);
 
         $response->assertSessionMissing('auth.register.passkey_creation_options');
@@ -139,6 +150,8 @@ trait SubmitPasskeyBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_email_is_required_when_initializing_passkey_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->initializePasskeyBasedRegisterAttempt(['email' => '']);
 
         $response->assertSessionMissing('auth.register.passkey_creation_options');
@@ -150,6 +163,8 @@ trait SubmitPasskeyBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_email_does_not_exceed_255_characters_when_initializing_passkey_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->initializePasskeyBasedRegisterAttempt(['email' => str_repeat('a', 256).'@example.com']);
 
         $response->assertSessionMissing('auth.register.passkey_creation_options');
@@ -161,6 +176,8 @@ trait SubmitPasskeyBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_email_is_valid_when_initializing_passkey_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->initializePasskeyBasedRegisterAttempt(['email' => 'foo']);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
@@ -171,6 +188,8 @@ trait SubmitPasskeyBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_user_does_not_already_exist_when_initializing_passkey_based_registration(): void
     {
+        $this->expectTimebox();
+
         $this->generateUser([$this->usernameField() => $this->defaultUsername()]);
 
         $response = $this->initializePasskeyBasedRegisterAttempt([$this->usernameField() => $this->defaultUsername()]);
@@ -187,6 +206,7 @@ trait SubmitPasskeyBasedRegistrationTests
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         $options = $this->mockPasskeyCreationOptions($user);
         Session::put('auth.register.passkey_creation_options', serialize($options));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->submitPasskeyBasedRegisterAttempt();
 
@@ -220,6 +240,8 @@ trait SubmitPasskeyBasedRegistrationTests
     public function it_cannot_confirm_passkey_based_registration_when_no_options_were_initialized(): void
     {
         Event::fake(Registered::class);
+        $this->expectTimebox();
+
         $response = $this->submitPasskeyBasedRegisterAttempt();
 
         $response->assertStatus(428);
@@ -236,6 +258,7 @@ trait SubmitPasskeyBasedRegistrationTests
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         $options = $this->mockPasskeyCreationOptions($user);
         Session::put('auth.register.passkey_creation_options', serialize($options));
+        $this->expectTimebox();
 
         $response = $this->postJson(route('register'), [
             'type' => 'passkey',
@@ -268,6 +291,7 @@ trait SubmitPasskeyBasedRegistrationTests
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         $options = $this->mockPasskeyCreationOptions($user);
         Session::put('auth.register.passkey_creation_options', serialize($options));
+        $this->expectTimebox();
 
         $response = $this->postJson(route('register'), [
             'type' => 'passkey',
@@ -291,6 +315,7 @@ trait SubmitPasskeyBasedRegistrationTests
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         $options = $this->mockPasskeyCreationOptionsTwo($user);
         Session::put('auth.register.passkey_creation_options', serialize($options));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->postJson(route('register'), [
             'type' => 'passkey',
@@ -329,6 +354,7 @@ trait SubmitPasskeyBasedRegistrationTests
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         $options = $this->mockPasskeyCreationOptionsTwo($user);
         Session::put('auth.register.passkey_creation_options', serialize($options));
+        $this->expectTimebox();
 
         $response = $this->postJson(route('register'), [
             'type' => 'passkey',
@@ -360,6 +386,7 @@ trait SubmitPasskeyBasedRegistrationTests
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         $options = $this->mockPasskeyCreationOptionsTwo($user);
         Session::put('auth.register.passkey_creation_options', serialize($options));
+        $this->expectTimebox();
 
         $response = $this->postJson(route('register'), [
             'type' => 'passkey',
@@ -390,6 +417,7 @@ trait SubmitPasskeyBasedRegistrationTests
         $user = $this->generateUser(['id' => 1, 'has_password' => false]);
         $options = $this->mockPasskeyCreationOptions($user);
         Session::put('auth.register.passkey_creation_options', serialize($options));
+        $this->expectSuccessfulTimebox();
 
         $response = $this->submitPasskeyBasedRegisterAttempt();
 

--- a/packages/core/src/Testing/Partials/SubmitPasswordBasedAuthenticationTests.php
+++ b/packages/core/src/Testing/Partials/SubmitPasswordBasedAuthenticationTests.php
@@ -21,7 +21,7 @@ trait SubmitPasswordBasedAuthenticationTests
     {
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $user = $this->generateUser();
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
@@ -150,7 +150,7 @@ trait SubmitPasswordBasedAuthenticationTests
     {
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $user = $this->generateUser();
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->submitPasswordBasedLoginAttempt(['remember' => 'on']);
 
@@ -170,7 +170,7 @@ trait SubmitPasswordBasedAuthenticationTests
 
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $user = $this->generateUser();
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
@@ -188,7 +188,7 @@ trait SubmitPasswordBasedAuthenticationTests
         Carbon::setTestNow(now());
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class, SudoModeEnabled::class]);
         $user = $this->generateUser();
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
@@ -209,7 +209,7 @@ trait SubmitPasswordBasedAuthenticationTests
     {
         $user = $this->generateUser();
         $this->assertNotEmpty($previousId = session()->getId());
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
@@ -226,7 +226,7 @@ trait SubmitPasswordBasedAuthenticationTests
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class, SudoModeEnabled::class]);
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create();
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 

--- a/packages/core/src/Testing/Partials/SubmitPasswordBasedAuthenticationTests.php
+++ b/packages/core/src/Testing/Partials/SubmitPasswordBasedAuthenticationTests.php
@@ -21,6 +21,7 @@ trait SubmitPasswordBasedAuthenticationTests
     {
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $user = $this->generateUser();
+        $this->expectSuccessfulTimebox();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
@@ -47,6 +48,8 @@ trait SubmitPasswordBasedAuthenticationTests
     /** @test */
     public function it_validates_that_the_username_is_required_during_password_based_authentication(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedLoginAttempt([$this->usernameField() => '']);
 
         $this->assertUsernameRequiredValidationError($response);
@@ -56,6 +59,8 @@ trait SubmitPasswordBasedAuthenticationTests
     /** @test */
     public function it_validates_that_the_username_is_valid_during_password_based_authentication(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedLoginAttempt([$this->usernameField() => $this->invalidUsername()]);
 
         $this->assertUsernameMustBeValidValidationError($response);
@@ -65,6 +70,8 @@ trait SubmitPasswordBasedAuthenticationTests
     /** @test */
     public function it_validates_that_the_password_is_required_during_password_based_authentication(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedLoginAttempt(['password' => '']);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
@@ -75,6 +82,8 @@ trait SubmitPasswordBasedAuthenticationTests
     /** @test */
     public function it_validates_that_the_password_is_a_string_during_password_based_authentication(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedLoginAttempt(['password' => 123]);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
@@ -87,6 +96,7 @@ trait SubmitPasswordBasedAuthenticationTests
     {
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $this->generateUser();
+        $this->expectTimebox();
 
         $response = $this->submitPasswordBasedLoginAttempt(['password' => 'invalid']);
 
@@ -103,6 +113,7 @@ trait SubmitPasswordBasedAuthenticationTests
     {
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $this->generateUser();
+        $this->expectTimebox();
 
         $response = $this->submitPasswordBasedLoginAttempt([
             $this->usernameField() => $this->nonExistentUsername(),
@@ -122,6 +133,7 @@ trait SubmitPasswordBasedAuthenticationTests
     {
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $this->generateUser(['has_password' => false]);
+        $this->expectTimebox();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
@@ -138,6 +150,7 @@ trait SubmitPasswordBasedAuthenticationTests
     {
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $user = $this->generateUser();
+        $this->expectSuccessfulTimebox();
 
         $response = $this->submitPasswordBasedLoginAttempt(['remember' => 'on']);
 
@@ -157,6 +170,7 @@ trait SubmitPasswordBasedAuthenticationTests
 
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class]);
         $user = $this->generateUser();
+        $this->expectSuccessfulTimebox();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
@@ -174,6 +188,7 @@ trait SubmitPasswordBasedAuthenticationTests
         Carbon::setTestNow(now());
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class, SudoModeEnabled::class]);
         $user = $this->generateUser();
+        $this->expectSuccessfulTimebox();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
@@ -194,6 +209,7 @@ trait SubmitPasswordBasedAuthenticationTests
     {
         $user = $this->generateUser();
         $this->assertNotEmpty($previousId = session()->getId());
+        $this->expectSuccessfulTimebox();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 
@@ -210,6 +226,7 @@ trait SubmitPasswordBasedAuthenticationTests
         Event::fake([Authenticated::class, AuthenticationFailed::class, MultiFactorChallenged::class, SudoModeEnabled::class]);
         $user = $this->generateUser();
         LaravelAuth::multiFactorCredentialModel()::factory()->totp()->forUser($user)->create();
+        $this->expectSuccessfulTimebox();
 
         $response = $this->submitPasswordBasedLoginAttempt();
 

--- a/packages/core/src/Testing/Partials/SubmitPasswordBasedRegistrationTests.php
+++ b/packages/core/src/Testing/Partials/SubmitPasswordBasedRegistrationTests.php
@@ -18,7 +18,7 @@ trait SubmitPasswordBasedRegistrationTests
     {
         Event::fake(Registered::class);
         $this->assertCount(0, LaravelAuth::userModel()::all());
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->submitPasswordBasedRegisterAttempt();
 
@@ -208,7 +208,7 @@ trait SubmitPasswordBasedRegistrationTests
     {
         Carbon::setTestNow(now());
         Event::fake([Registered::class, SudoModeEnabled::class]);
-        $this->expectSuccessfulTimebox();
+        $this->expectTimeboxWithEarlyReturn();
 
         $response = $this->submitPasswordBasedRegisterAttempt();
 

--- a/packages/core/src/Testing/Partials/SubmitPasswordBasedRegistrationTests.php
+++ b/packages/core/src/Testing/Partials/SubmitPasswordBasedRegistrationTests.php
@@ -18,6 +18,7 @@ trait SubmitPasswordBasedRegistrationTests
     {
         Event::fake(Registered::class);
         $this->assertCount(0, LaravelAuth::userModel()::all());
+        $this->expectSuccessfulTimebox();
 
         $response = $this->submitPasswordBasedRegisterAttempt();
 
@@ -47,6 +48,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_name_is_required_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedRegisterAttempt(['name' => '']);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
@@ -57,6 +60,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_name_is_a_string_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedRegisterAttempt(['name' => 123]);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
@@ -67,6 +72,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_name_does_not_exceed_255_characters_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedRegisterAttempt(['name' => str_repeat('a', 256)]);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
@@ -77,6 +84,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_username_is_required_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedRegisterAttempt([$this->usernameField() => '']);
 
         $this->assertUsernameRequiredValidationError($response);
@@ -86,6 +95,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_username_does_not_exceed_255_characters_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedRegisterAttempt([$this->usernameField() => $this->tooLongUsername()]);
 
         $this->assertUsernameTooLongValidationError($response);
@@ -95,6 +106,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_email_is_required_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedRegisterAttempt(['email' => '']);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
@@ -105,6 +118,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_email_does_not_exceed_255_characters_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedRegisterAttempt(['email' => str_repeat('a', 256).'@example.com']);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
@@ -115,6 +130,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_email_is_valid_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedRegisterAttempt(['email' => 'foo']);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
@@ -125,6 +142,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_user_does_not_already_exist_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $this->generateUser([$this->usernameField() => $this->defaultUsername()]);
 
         $response = $this->submitPasswordBasedRegisterAttempt([$this->usernameField() => $this->defaultUsername()]);
@@ -136,6 +155,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_password_is_required_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedRegisterAttempt(['password' => '']);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
@@ -146,6 +167,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_password_confirmation_is_required_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedRegisterAttempt(['password_confirmation' => '']);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
@@ -156,6 +179,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_password_is_confirmed_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedRegisterAttempt(['password_confirmation' => 'invalid-password-confirmation']);
 
         $this->assertInstanceOf(ValidationException::class, $response->exception);
@@ -166,6 +191,8 @@ trait SubmitPasswordBasedRegistrationTests
     /** @test */
     public function it_validates_that_the_password_default_rules_are_applied_during_password_based_registration(): void
     {
+        $this->expectTimebox();
+
         $response = $this->submitPasswordBasedRegisterAttempt([
             'password' => 'foo',
             'password_confirmation' => 'foo',
@@ -181,6 +208,7 @@ trait SubmitPasswordBasedRegistrationTests
     {
         Carbon::setTestNow(now());
         Event::fake([Registered::class, SudoModeEnabled::class]);
+        $this->expectSuccessfulTimebox();
 
         $response = $this->submitPasswordBasedRegisterAttempt();
 

--- a/packages/core/src/Testing/Support/InstantlyResolvingTimebox.php
+++ b/packages/core/src/Testing/Support/InstantlyResolvingTimebox.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ClaudioDekker\LaravelAuth\Testing\Support;
+
+use Illuminate\Support\Timebox;
+
+class InstantlyResolvingTimebox extends Timebox
+{
+    /**
+     * Intended for testing purposes only, not for production use.
+     *
+     * @see Timebox::call()
+     */
+    public function call(callable $callback, int $microseconds)
+    {
+        return $callback($this);
+    }
+}


### PR DESCRIPTION
This PR [Timeboxes](https://github.com/laravel/framework/pull/44069) sensitive requests that are worth timeboxing, to avoid potential time-based attacks to determine or extract information about an user:

https://securinglaravel.com/p/in-depth-timing-attacks
> As the name implies, a timing attack is an technique that uses timing to infer some knowledge that you shouldn’t normally have access to.
>
> Since computers are fundamentally predictable, and everything about them is based off timing and available resources, we can glean a lot of knowledge by simply measuring how long it takes to complete a request.
>
>> If you’ve got kids you’ll be familiar with the “brush your teeth” dance we play each day: you ask them to go brush their teeth, they spend exactly 5 milliseconds in the bathroom, and then can’t understand why you know they haven’t brushed their teeth yet!

https://securinglaravel.com/p/security-tip-timebox-for-timing-attacks:
> There is a specific technique called a Timeless Timing Attack that uses HTTP/2 multiplexing to send multiple requests at the same time, allowing you to easily compare the timing of specific requests without needing to account for slow connections, rate limiting, attempt limits, etc