### PR TITLE
UserFactory: Use `fake()` helper instead of `$this->faker`

### DIFF
--- a/packages/core/templates/Database/UserFactory.bladetmpl
+++ b/packages/core/templates/Database/UserFactory.bladetmpl
@@ -16,11 +16,11 @@ class UserFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->name(),
+            'name' => fake()->name(),
 @if ($flavor === 'username-based')
-            'username' => $this->faker->unique()->username(),
+            'username' => fake()->unique()->username(),
 @endif
-            'email' => $this->faker->safeEmail(),
+            'email' => fake()->safeEmail(),
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),


### PR DESCRIPTION
Laravel scaffolds with the `fake()` helper instead of `$this->faker` attribute, this change is being reflected here.

See https://github.com/laravel/laravel/blob/10.x/database/factories/UserFactory.php